### PR TITLE
Provide basic docker setup on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,6 +68,7 @@ environment:
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      # setting critically needed for launching the dataverse container
       traefikhost: localhost
     # Windows core tests
     - ID: WinP39core

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,10 +64,11 @@ environment:
     - ID: Ubu20
       DTS: datalad_dataverse
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      INSTALL_SYSPKGS: python3-virtualenv
+      INSTALL_SYSPKGS: python3-virtualenv jq
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      traefikhost: localhost
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -76,6 +77,7 @@ environment:
       # Python version specification is non-standard on windows
       PY: 39-x64
       INSTALL_GITANNEX: git-annex -m datalad/packages
+      traefikhost: localhost
     # MacOS core tests
     - ID: MacP38core
       DTS: datalad_dataverse
@@ -165,7 +167,10 @@ install:
   #- sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
   # add location of datalad installer results to PATH
   #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
-
+  # Set up dataverse docker (Ubuntu build only):
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh; else true; fi;"
+  # Show what we got after setup in case something is going wrong:
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $TESTS_TOKEN_PETE $TESTS_TOKEN_UMA\"; else true; fi;"
 
 #before_build:
 #

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,7 +78,6 @@ environment:
       # Python version specification is non-standard on windows
       PY: 39-x64
       INSTALL_GITANNEX: git-annex -m datalad/packages
-      traefikhost: localhost
     # MacOS core tests
     - ID: MacP38core
       DTS: datalad_dataverse
@@ -168,10 +167,12 @@ install:
   #- sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
   # add location of datalad installer results to PATH
   #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
-  # Set up dataverse docker (Ubuntu build only):
+  # Set up dataverse docker (Ubuntu build only); sourced since it's exporting the API tokens:
   - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh; else true; fi;"
   # Show what we got after setup in case something is going wrong:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $TESTS_TOKEN_PETE $TESTS_TOKEN_UMA\"; else true; fi;"
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $TESTS_TOKEN_TESTADMIN $TESTS_TOKEN_USER1\"; else true; fi;"
+  # Check we got a our dataverse and it's accessible with the admin token:
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then curl \"http://localhost:8080/api/search?q=*&type=dataverse&key=${TESTS_TOKEN_TESTADMIN}\"; else true; fi;"
 
 #before_build:
 #

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ consider acknowledging contributors with the
 [allcontributors bot](https://allcontributors.org/docs/en/bot/overview).
 
 
-## Dataverse docker
+## Dataverse docker for running tests
 
 The [dataverse-docker](https://github.com/IQSS/dataverse-docker) repository 
 provides everything needed to run dataverse in a container. The continuous 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DataLad extension template
+# DataLad Dataverse extension
 
 [![Build status](https://ci.appveyor.com/api/projects/status/fm24tes0vxlq7qis/branch/master?svg=true)](https://ci.appveyor.com/project/mih/datalad-dataverse/branch/master) [![codecov.io](https://codecov.io/github/datalad/datalad-dataverse/coverage.svg?branch=master)](https://codecov.io/github/datalad/datalad-dataverse?branch=master) [![crippled-filesystems](https://github.com/datalad/datalad-dataverse/workflows/crippled-filesystems/badge.svg)](https://github.com/datalad/datalad-dataverse/actions?query=workflow%3Acrippled-filesystems) [![docs](https://github.com/datalad/datalad-dataverse/workflows/docs/badge.svg)](https://github.com/datalad/datalad-dataverse/actions?query=workflow%3Adocs)
 
@@ -46,3 +46,71 @@ to acknowledge contributors and describe the publication record that is created 
 by archiving it using [zenodo.org](https://zenodo.org/). You may also want to
 consider acknowledging contributors with the
 [allcontributors bot](https://allcontributors.org/docs/en/bot/overview).
+
+
+## Dataverse docker
+
+The [dataverse-docker](https://github.com/IQSS/dataverse-docker) repository 
+provides everything needed to run dataverse in a container. The continuous 
+integration test build is based on that. The setup script used for the 
+respective AppVeyor build is under `tools/ci/setup_docker_dataverse`.
+
+You can use this docker setup locally on your machine, too, provided it's 
+running Linux and you have `docker` and `docker-compose` installed. All 
+involved scripts (from our end as well as the dataverse-docker repo) are 
+completely ignorant of Windows.
+The basic setup is this:
+
+    git clone https://github.com/IQSS/dataverse-docker
+    cd dataverse-docker
+    export traefikhost=localhost
+    docker network create traefik
+    cp .env_sample .env
+
+If you want to customize your setup, you may want to edit this `.env` file.
+Note, that the following call to `docker-compose` relies on being in the 
+directory of the docker-compose file and that `.env`. If that's not suitable 
+in your case, `docker-compose` provides a `--file` and a `--env-file` parameter.
+
+    docker-compose up -d
+
+This should give you a running server at `http://localhost:8080`. Note, that 
+it may take a moment for the server to come up. If you go to that address in 
+a browser you should be abe to log in as `dataverseAdmin` with password 
+`admin` (which you will instantly be required to change). This allows to 
+create dataverses, datasets, files, etc. An API token for that user is to be 
+found under that user's menu (upper right).
+
+Apart from the webinterface, you should be able to send some basic requests:
+
+    $> curl "http://localhost:8080/api/search?q=data"
+    {"status":"OK","data":{"q":"data","total_count":0,"start":0,"spelling_alternatives":{},"items":[],"count_in_response":0}}
+    $> curl "http://localhost:8080/api/dataverses/root/contents"                                                                                                                   
+    {"status":"ERROR","message":"User :guest is not permitted to perform requested action."}                                                                                            
+
+With the token the latter response would change if you authenticate that way:
+
+    $> curl -H X-Dataverse-key:<TOKEN> "http://localhost:8080/api/dataverses/root/contents"
+    {"status":"OK","data":[{"type":"dataverse","id":2,"title":"Dataverse Admin Dataverse"}]}
+
+Several additional notes:
+
+- The initial `docker-compose` call could give an error message if you 
+  already have an active port mapping. However, this does not necessarily 
+  mean you need to change. It may work just fine. Try despite such an error 
+  message.
+- This is only the most basic setup. Within the container there are a bunch 
+  of setup scripts to initialize the demo version. If you get into the 
+  container, you can find them in HOME (`/opt/payara/dvinstall`). You may 
+  want to check out `init-setup.sh`, `setup-dvs.sh`, `setup-users.sh` (see 
+  also the aforementioned script in this repository here.)
+- The dataverse-docker repo comes with a bunch of docker-compose recipes. We 
+  currently use just the default.
+- If you run this locally and need to start over for some reason, note that 
+  there is some persistent files that would need to be wiped out, too. They 
+  are generated during the setup described earlier. A `git status` or 
+  `datalad status` should show you the `.env` file and a `minio-data/` 
+  directory as untracked. However, there's one more: `database-data/`. That 
+  one is readable only by `root`, hence a regular user's `git status` 
+  doesn't show it. A `sudo git status` would confirm, that this is untracked,
+  too.

--- a/tools/ci/dladmin.json
+++ b/tools/ci/dladmin.json
@@ -1,0 +1,8 @@
+{
+    "firstName":"Datalad",
+    "lastName":"Testadmin",
+    "userName":"testadmin",
+    "affiliation":"datalad.org",
+    "position":"Admin",
+    "email":"dltestadmin@datalad.org"
+}

--- a/tools/ci/init_dataverse.sh
+++ b/tools/ci/init_dataverse.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e -u
+# This script is meant to setup the inital users and data for datalad-dataverse's
+# tests. It is supposed to be run from within the container (as root) and called
+# accordingly by setup_docker_dataverse.sh
+
+SERVER=http://localhost:8080/api
+curl -X PUT -d burrito $SERVER/admin/settings/BuiltinUsers.KEY
+
+# create our admin
+admin=$(curl -s -H "Content-type:application/json" -X POST -d @data/dladmin.json "$SERVER/builtin-users?password=dladmin1&key=burrito")
+adminToken=$(echo "$admin" | jq .data.apiToken | tr -d \")
+printf "\n%b\n" "Token for testadmin: ${adminToken}"
+# Actually make superuser:
+# TODO: double check output and possibly swallow/analyze
+curl -X POST "http://localhost:8080/api/admin/superuser/testadmin"
+
+# a second user
+userOne=$(curl -s -H "Content-type:application/json" -X POST -d @data/user1.json "$SERVER/builtin-users?password=password1&key=burrito")
+userOneToken=$(echo "$userOne" | jq .data.apiToken | tr -d \")
+printf "\n%b\n" "Token for user1: ${userOneToken}"
+
+# a root dataverse:
+# TODO: double check output and possibly swallow/analyze
+curl -s -H "Content-type:application/json" -X POST -d @data/root-dv.json "$SERVER/dataverses/root?key=$adminToken"
+

--- a/tools/ci/root-dv.json
+++ b/tools/ci/root-dv.json
@@ -1,0 +1,15 @@
+{
+  "name": "Scientific Research",
+  "alias": "science",
+  "dataverseContacts": [
+    {
+      "contactEmail": "pi@example.edu"
+    },
+    {
+      "contactEmail": "student@example.edu"
+    }
+  ],
+  "affiliation": "Scientific Research University",
+  "description": "We do all the science.",
+  "dataverseType": "LABORATORY"
+}

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e -u
 # This is setting up and launching a docker container with everything needed for
 # our tests to run against this instance.
 # Most importantly with respect to the CI builds, it deposits the API tokens
@@ -21,50 +22,73 @@ git clone https://github.com/IQSS/dataverse-docker
 docker network create traefik
 cp dataverse-docker/.env_sample dataverse-docker/.env
 docker-compose --file dataverse-docker/docker-compose.yml --env-file dataverse-docker/.env up -d
-# On AppVeyor the server takes a while to become responsive.
-# Note: We probably want to integrate the containers' `init-setup.sh`, which
-# implements a way to keep probing the server until it's up rather than
-# waiting a fix amount of time.
-sleep 300
-
+# Wait for the API to become responsive. Note, that on AppVeyor it has been seen
+# to take more than 4 minutes. However, time out after 10 min.
+counter=0
+set +e
+# Note: `tee >(cat 1>&2)` does copy stdout to stderr in order see what was the
+# actual output of curl in the CI log despite it being piped into `jq`.
+# curl's `--silent --show-error`, disables displaying metrics for every single
+# trial, polluting the log with useless information, while actual error
+# messages still show up.
+until [ "$(curl --silent --show-error "http://localhost:8080/api/search?q=whatever" | tee >(cat 1>&2) | jq .status)" == "\"OK\"" ]
+do
+  if [ $counter -gt 120 ]; then
+    echo "Dataverse API unresponsive after 10 minutes. Giving up."
+    exit 1
+  fi
+  sleep 5
+  ((counter++))
+done
+set -e
 
 ### Now, get users and there tokens for use with the tests
 docker_id="$(docker ps -qf name="^dataverse$")"
 echo "Dataverse container id: ${docker_id}"
 
+# Put our data definitions in the container, so the setup API requests
+# executed from within can access them:
+docker cp tools/ci/dladmin.json "${docker_id}:/opt/payara/dvinstall/data/dladmin.json"
+docker cp tools/ci/user1.json "${docker_id}:/opt/payara/dvinstall/data/user1.json"
+docker cp tools/ci/root-dv.json "${docker_id}:/opt/payara/dvinstall/data/root-dv.json"
+docker cp tools/ci/init_dataverse.sh "${docker_id}:/opt/payara/dvinstall/init_dataverse.sh"
+
+
 # setup-users.sh comes with installation. Its output is some text, some JSON and
 # finally two lines giving the tokens for users 'pete' and 'uma'
-tokens=$(docker exec "${docker_id}" /opt/payara/dvinstall/setup-users.sh | grep "result" | awk '{print $5}')
-token_pete=$(echo "${tokens}" | awk 'NR==1')
-token_uma=$(echo "${tokens}" | awk 'NR==2')
+initresponse=$(docker exec "${docker_id}" /opt/payara/dvinstall/init_dataverse.sh)
+tokens=$(echo "$initresponse" | grep "Token for" | awk '{print $4}')
 
-# Check validity of received token for 'pete'
-if [ -n "${token_pete}" ] && [ "${token_pete}" != "null" ]; then
-  echo "Token for 'pete' received: ${token_pete}"
-  peteResp=$(curl -H "X-Dataverse-key:${token_pete}" "http://localhost:8080/api/users/:me")
-  if [ $(echo "${peteResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${peteResp}" | jq .data.firstName) == "\"Pete\"" ]; then
+token_admin=$(echo "${tokens}" | awk 'NR==1')
+token_userone=$(echo "${tokens}" | awk 'NR==2')
+
+# Check validity of received token for 'testadmin'
+if [ -n "${token_admin}" ] && [ "${token_userone}" != "null" ]; then
+  echo "Token for 'testadmin' received: ${token_admin}"
+  adminResp=$(curl -H "X-Dataverse-key:${token_admin}" "http://localhost:8080/api/users/:me")
+  if [ $(echo "${adminResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${adminResp}" | jq .data.firstName) == "\"Datalad\"" ]; then
     echo "Token confirmed."
-    export TESTS_TOKEN_PETE=${token_pete}
+    export TESTS_TOKEN_TESTADMIN=${token_admin}
   else
-    echo "Failed to use token. User query response: ${peteResp}"
+    echo "Failed to use token. User query response: ${adminResp}"
     exit 1
   fi
 else
-  echo "Failed to receive token for 'pete'. Got: ${token_pete}"
+  echo "Failed to receive token for 'testadmin'. Got: ${token_admin}"
   exit 1
 fi
 # Check validity of received token for 'uma'
-if [ -n "${token_uma}" ] && [ "${token_uma}" != "null" ]; then
-  echo "Token for 'uma' received: ${token_uma}"
-  umaResp=$(curl -H "X-Dataverse-key:${token_uma}" "http://localhost:8080/api/users/:me")
-  if [ $(echo "${umaResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${umaResp}" | jq .data.firstName) == "\"Uma\"" ]; then
+if [ -n "${token_userone}" ] && [ "${token_userone}" != "null" ]; then
+  echo "Token for 'user1' received: ${token_userone}"
+  useroneResp=$(curl -H "X-Dataverse-key:${token_userone}" "http://localhost:8080/api/users/:me")
+  if [ $(echo "${useroneResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${useroneResp}" | jq .data.firstName) == "\"Regular\"" ]; then
     echo "Token confirmed."
-    export TESTS_TOKEN_UMA=${token_uma}
+    export TESTS_TOKEN_USER1=${token_userone}
   else
-    echo "Failed to use token. User query response: ${umaResp}"
+    echo "Failed to use token. User query response: ${useroneResp}"
     exit 1
   fi
 else
-  echo "Failed to receive token for 'uma'. Got: ${token_uma}"
+  echo "Failed to receive token for 'user1'. Got: ${token_userone}"
   exit 1
 fi

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# This is setting up the (already running!) server with everything needed for
+# our tests to run against this instance.
+# Most importantly with respect to the CI builds, it deposits the API tokens
+# for the users `pete` and `uma` in environment variabes TEST_TOKEN_PETE and
+# TEST_TOKEN_UMA respectively for use from within unit tests. Therefore this
+# script is supposed to be sourced.
+
+# For administrative tasks at the beginning, we need to execute request from
+# within the container, since the respective API endpoints are only accessible
+# from 'localhost' (from the POV of the dataverse server). Hence, finding the
+# container ID and running via `docker exec` is required.
+
+# Note, that there are a couple more setup scripts already available in the
+# container in /opt/payara/dvinstall besides the currently used `setup-users.sh`.
+# We may want to use more of them.
+# Consider especially init-setup.sh, setup-dvs.sh
+
+### Initial container setup
+git clone https://github.com/IQSS/dataverse-docker
+docker network create traefik
+cp dataverse-docker/.env_sample dataverse-docker/.env
+docker-compose --file dataverse-docker/docker-compose.yml --env-file dataverse-docker/.env up -d
+# On AppVeyor the server takes a while to become responsive.
+# Note: We probably want to integrate the containers' `init-setup.sh`, which
+# implements a way to keep probing the server until it's up rather than
+# waiting a fix amount of time.
+sleep 300
+
+
+### Now, get users and there tokens for use with the tests
+docker_id="$(docker ps -qf name="^dataverse$")"
+echo "Dataverse container id: ${docker_id}"
+
+# setup-users.sh comes with installation. Its output is some text, some JSON and
+# finally two lines giving the tokens for users 'pete' and 'uma'
+tokens=$(docker exec "${docker_id}" /opt/payara/dvinstall/setup-users.sh | grep "result" | awk '{print $5}')
+token_pete=$(echo "${tokens}" | awk 'NR==1')
+token_uma=$(echo "${tokens}" | awk 'NR==2')
+
+# Check validity of received token for 'pete'
+if [ -n "${token_pete}" ] && [ "${token_pete}" != "null" ]; then
+  echo "Token for 'pete' received: ${token_pete}"
+  peteResp=$(curl -H "X-Dataverse-key:${token_pete}" "http://localhost:8080/api/users/:me")
+  if [ $(echo "${peteResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${peteResp}" | jq .data.firstName) == "\"Pete\"" ]; then
+    echo "Token confirmed."
+    export TESTS_TOKEN_PETE=${token_pete}
+  else
+    echo "Failed to use token. User query response: ${peteResp}"
+    exit 1
+  fi
+else
+  echo "Failed to receive token for 'pete'. Got: ${token_pete}"
+  exit 1
+fi
+# Check validity of received token for 'uma'
+if [ -n "${token_uma}" ] && [ "${token_uma}" != "null" ]; then
+  echo "Token for 'uma' received: ${token_uma}"
+  umaResp=$(curl -H "X-Dataverse-key:${token_uma}" "http://localhost:8080/api/users/:me")
+  if [ $(echo "${umaResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${umaResp}" | jq .data.firstName) == "\"Uma\"" ]; then
+    echo "Token confirmed."
+    export TESTS_TOKEN_UMA=${token_uma}
+  else
+    echo "Failed to use token. User query response: ${umaResp}"
+    exit 1
+  fi
+else
+  echo "Failed to receive token for 'uma'. Got: ${token_uma}"
+  exit 1
+fi

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This is setting up the (already running!) server with everything needed for
+# This is setting up and launching a docker container with everything needed for
 # our tests to run against this instance.
 # Most importantly with respect to the CI builds, it deposits the API tokens
 # for the users `pete` and `uma` in environment variabes TEST_TOKEN_PETE and

--- a/tools/ci/user1.json
+++ b/tools/ci/user1.json
@@ -1,0 +1,8 @@
+{
+    "firstName":"Regular",
+    "lastName":"User",
+    "userName":"user1",
+    "affiliation":"datalad.org",
+    "position":"DoesThisMatter",
+    "email":"user1@datalad.org"
+}


### PR DESCRIPTION
Closes #2

This sets up a dataverse docker instance in the Ubuntu AppVeyor build. It's NOT provided on macOS and Windows. However, I think this should suffice, since the project isn't about running dataverse - the server system doesn't really matter for us.

Currently, this is not yet set up to use HTTPS, but only HTTP. Again, I don't think it's crucial to get going, but would be a nice-to-have.

- [x] Figure out, how to set up authentication (and prob. one or two test users besides admin) non-interactively.
- [x] Put description into README (currently only [here](https://github.com/datalad/datalad-dataverse/issues/2#issuecomment-1143231503))