### PR TITLE
Setup requirements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -179,8 +179,9 @@ install:
 
 
 build_script:
+  - python -m pip install -r requirements.txt
   - python -m pip install -r requirements-devel.txt
-  - python -m pip install .
+  - python -m pip install ".[devel]"
 
 
 #after_build:
@@ -197,9 +198,10 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-    # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_dataverse %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_dataverse ${DTS}
+    # run test selecion
+  - cmd: python -m pytest -s -v -m "not (turtle)" --cov=datalad_dataverse --pyargs %DTS%
+  - sh: PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v -m "not (turtle)" --cov=datalad_dataverse --pyargs ${DTS}
+
 
 
 after_test:

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install -r requirements-devel.txt
         pip install .
     - name: Build docs

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -34,12 +34,13 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
+        pip install -r requirements.txt
         pip install -r requirements-devel.txt
         python -m pip install --upgrade pip
     - name: Installation
       run: |
         # package install
-        python -m pip install .
+        python -m pip install ".[devel]"
     - name: Run tests
       env:
         # forces all test repos/paths into the VFAT FS
@@ -52,4 +53,4 @@ jobs:
         echo "== mount >>"
         mount
         echo "<< mount =="
-        python -m nose -s -v --with-doctest --with-coverage --cover-package datalad_dataverse datalad_dataverse
+        PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v --doctest-modules --cov=datalad_dataverse --pyargs datalad_dataverse

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         pip install -r requirements.txt

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,5 @@
 The following people have contributed to this project:
 
 Michael Hanke
+Adina Wagner
+Benjamin Poldrack

--- a/datalad_dataverse/__init__.py
+++ b/datalad_dataverse/__init__.py
@@ -26,9 +26,6 @@ command_suite = (
     ]
 )
 
-from datalad import setup_package
-from datalad import teardown_package
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/datalad_dataverse/conftest.py
+++ b/datalad_dataverse/conftest.py
@@ -1,0 +1,15 @@
+try:
+    from datalad.conftest import setup_package
+except ImportError:
+    # assume old datalad without pytest support introduced in
+    # https://github.com/datalad/datalad/pull/6273
+    import pytest
+    from datalad import setup_package as _setup_package
+    from datalad import teardown_package as _teardown_package
+
+
+    @pytest.fixture(autouse=True, scope="session")
+    def setup_package():
+        _setup_package()
+        yield
+        _teardown_package()

--- a/datalad_dataverse/tests/test_register.py
+++ b/datalad_dataverse/tests/test_register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def test_register():

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,3 @@
 # requirements for a development environment
-nose
-coverage
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# we need datalad from the future with pytest for now (will be a datalad-next
+# that depends on datalad 0.17)
+git+https://github.com/datalad/datalad

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-url = https://github.com/datalad/datalad-extension-template
+url = https://github.com/datalad/datalad-dataverse
 author = The DataLad Team and Contributors
 author_email = team@datalad.org
 description = demo DataLad extension package
@@ -14,14 +14,16 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
-    datalad >= 0.12.0
+    datalad-next >= 0.3.0
+    pydataverse
 packages = find:
 include_package_data = True
 
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    nose
+    pytest
+    pytest-cov
     coverage
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.7
 install_requires =
     datalad-next >= 0.3.0
     pydataverse

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -33,11 +33,11 @@ set +e
 # messages still show up.
 until [ "$(curl --silent --show-error "http://localhost:8080/api/search?q=whatever" | tee >(cat 1>&2) | jq .status)" == "\"OK\"" ]
 do
-  if [ $counter -gt 120 ]; then
+  if [ $counter -gt 60 ]; then
     echo "Dataverse API unresponsive after 10 minutes. Giving up."
     exit 1
   fi
-  sleep 5
+  sleep 10
   ((counter++))
 done
 set -e


### PR DESCRIPTION
For now we need to depend on datalad-next
as well as datalad from the future.
The former for credentials, the latter for
proper pytest support. This will change when
datalad 0.17 is released (and a subsequent
datalad-next release).

Otherwise we need pydataverse for now.

Closes #29 