### PR TITLE
add basic implementation of initremote

### DIFF
--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -8,7 +8,7 @@ class DataverseRemote(SpecialRemote):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.configs['url'] = 'The OSF URL for the remote'
+        self.configs['url'] = 'The Dataverse URL for the remote'
         self.configs['doi'] = 'DOI to the dataset'
 
     def initremote(self):

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -1,10 +1,37 @@
 from datalad.customremotes import SpecialRemote
 from datalad.customremotes.main import main as super_main
+from pyDataverse.api import NativeApi
+import os
 
 
 class DataverseRemote(SpecialRemote):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.configs['url'] = 'The OSF URL for the remote'
+        self.configs['doi'] = 'DOI to the dataset'
+
     def initremote(self):
-        raise
+        """
+            Use this command to initialize a remote
+            git annex initremote dv1 type=external externaltype=dataverse encryption=none
+        """
+        if self.annex.getconfig('url') is None or self.annex.getconfig('doi') is None:
+            raise ValueError('url and doi must be specified')
+
+        # connect to dataverse instance
+        api = NativeApi(base_url=self.annex.getconfig('url'),
+                        api_token=os.environ["DATAVERSE_API_TOKEN"])
+
+        # check if instance is readable and authenticated
+        resp = api.get_info_version()
+        if resp.json()['status'] != 'OK':
+            raise RuntimeError(f'Cannot connect to dataverse instance (status: {resp.json()["status"]})')
+
+        # check if project with specified doi exists
+        dv_ds = api.get_dataset(identifier=self.annex.getconfig('doi'))
+        if not dv_ds.ok:
+            raise RuntimeError("Cannot find dataset")
 
     def prepare(self):
         raise


### PR DESCRIPTION
This PR implements a basic version of the initremote method. It forces the user to provide the URL to the dataverse instance and the doi to the dataset and checks whether the instance and dataset exist.