### PR TITLE
Add dockerhub login to CI for more container pulls

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -168,7 +168,8 @@ install:
   # add location of datalad installer results to PATH
   #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
   # Set up dataverse docker (Ubuntu build only); sourced since it's exporting the API tokens:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh; else true; fi;"
+  - sh: echo "$DOCKERHUB_TOKEN $DOCKERHUB_USERNAME"
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh $DOCKERHUB_TOKEN $DOCKERHUB_USERNAME; else true; fi;"
   # Show what we got after setup in case something is going wrong:
   - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $TESTS_TOKEN_TESTADMIN $TESTS_TOKEN_USER1\"; else true; fi;"
   # Check we got a our dataverse and it's accessible with the admin token:

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -3,8 +3,17 @@ name: crippled-filesystems
 on: [pull_request]
 
 jobs:
-  test:
+  login:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -17,6 +17,13 @@ set -e -u
 # We may want to use more of them.
 # Consider especially init-setup.sh, setup-dvs.sh
 
+# log into Dockerhub to pull more images if the required variables are passed
+if [[ ! -z "$1" ]] && [[ ! -z "$2" ]]; then
+  DOCKERHUB_TOKEN="$1"
+  DOCKERHUB_USERNAME="$2"
+  docker login --password ${DOCKERHUB_TOKEN} --username ${DOCKERHUB_USERNAME}
+fi
+
 ### Initial container setup
 git clone https://github.com/IQSS/dataverse-docker
 docker network create traefik


### PR DESCRIPTION
Unauthenticated pulls from the same IP are limited; you get double the amount when authenticating with a  free account. This PR adds the necessary log in to the CI