### PR TITLE
DOC: add glossary page to define how Dataverse and DataLad terms relate

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,21 @@
+..  _glossary:
+
+Glossary
+========
+
+.. list-table:: Mapping Terms
+   :header-rows: 1
+
+   * - Dataverse
+     - DataLad
+     - Description
+   * - collection
+     - superdataset
+     - 
+   * - dataset
+     - dataset
+     - 
+   * - linking
+     - nesting
+     - 
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,14 @@ The aim of this project is to make DataLad interoperable with Dataverse to
 support dataset transport from and to Dataverse instances. It originates 
 from `OHBM BrainHack 2022 <https://github.com/ohbm/hackathon2022/issues/43>`__.  
 
+Documentation overview
+======================
+
+.. toctree::
+   :maxdepth: 1
+
+   glossary
+
 API
 ===
 


### PR DESCRIPTION
Here is just the start of a table to compare the terms.