### PR TITLE
Support datalad-clone directly from dataset landing page

### DIFF
--- a/datalad_dataverse/__init__.py
+++ b/datalad_dataverse/__init__.py
@@ -26,6 +26,25 @@ command_suite = (
     ]
 )
 
+from datalad.support.extensions import register_config
+register_config(
+    'datalad.clone.url-substitute.dataverse',
+    'clone URL substitution for dataverse dataset landing pages',
+    description="Convenience conversion of Dataverse dataset landing page "
+    "URLs to git-cloneable 'datalad-annex::'-type URLs. It enables cloning "
+    "from dataset webpage directly, and implies a remote sibling in 'annex' "
+    "mode (i.e., with keys, not exports) "
+    "See https://docs.datalad.org/design/url_substitution.html for details",
+    dialog='question',
+    scope='global',
+    default=(
+        r',^(http[s]*://.*)/dataset.xhtml\?persistentId=(doi:[^&]+)(.*)$'
+        r',datalad-annex::?type=external&externaltype=dataverse'
+        r'&url=\1&doi=\2&encryption=none',
+    ),
+)
+
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -9,6 +9,7 @@ from datalad.tests.utils_pytest import (
     skip_if,
     with_tempfile,
 )
+from datalad.utils import rmtree
 
 from datalad_dataverse.tests.utils import (
     create_test_dataverse_collection,
@@ -96,8 +97,17 @@ def _check_datalad_annex(ds, dspid, clonepath):
     repo.call_git(['remote', 'add', 'mydv', git_remote_url])
     repo.call_git(['push', 'mydv', '--all'])
 
-    dsclone = clone(git_remote_url, clonepath)
+    for url in (
+        # generic monster URL
+        git_remote_url,
+        # actual dataset landing page
+        f'{DATAVERSE_URL}/dataset.xhtml?persistentId={dspid}&version=DRAFT',
+    ):
+        dsclone = clone(git_remote_url, clonepath)
 
-    # we got the same thing
-    assert repo.get_hexsha(ds.repo.get_corresponding_branch()) == \
-        dsclone.repo.get_hexsha(ds.repo.get_corresponding_branch())
+        # we got the same thing
+        assert repo.get_hexsha(ds.repo.get_corresponding_branch()) == \
+            dsclone.repo.get_hexsha(ds.repo.get_corresponding_branch())
+
+        # cleanup for the next iteration
+        rmtree(clonepath)


### PR DESCRIPTION
This is implemented via a custom URL mapping config

```
datalad.clone.url-substitute.dataverse=(',^(http[s]*://.*)/dataset.xhtml\\?persistentId=(doi:[^&]+)(.*)$,datalad-annex::?type=external&externaltype=dataverse&url=\\1&doi=\\2&encryption=none',)
```

for this to work, users have to configure the dataverse extension for
auto-loading, but setting the `datalad.extensions.load=dataverse`
config switch in the `global` scope.

For now, this convenience expects a dataset deposit in non-export mode.
But we might want to revisit that later.

Closes #87 