### PR TITLE
DOC: reformat glossary and add basic descriptions

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -3,19 +3,27 @@
 Glossary
 ========
 
-.. list-table:: Mapping Terms
-   :header-rows: 1
+DataLad and Dataverse have a few central concepts that are similar, but not synonymous.
+The overview below can help you delineate and map the two software's key concepts, and you can find more information in the respective tool's documentation (`Dataverse docs <https://guides.dataverse.org/en/latest/user>`_, `DataLad docs <http://handbook.datalad.org/en/latest/>`_).
 
-   * - Dataverse
-     - DataLad
-     - Description
-   * - collection
-     - superdataset
-     - 
-   * - dataset
-     - dataset
-     - 
-   * - linking
-     - nesting
-     - 
+
+.. Glossary::
+
+  Dataverse dataset
+     Dataverse datasets contain digital files (research data, code, ...), amended with additional metadata. They typically live inside of dataverse collections.
+
+  DataLad dataset
+     DataLad datasets are joint Git/git-annex repositories that can version control digital files. The datalad-dataverse extension allows you to publish DataLad datasets as Dataverse datasets.
+
+  Dataverse collection.
+     A Dataverse collection (sometimes only referred to as "Dataverse") can contain other Dataverse collections or Dataverse datasets.
+
+  DataLad superdataset
+     A DataLad superdataset contains other DataLad datasets. This linkage can be arbitrarily deep.
+
+  Dataverse linking
+     Dataverse can link to other dataverses, or datasets in other collections.
+
+  DataLad nesting
+     DataLad datasets can be nested in one another in arbitrarily deep hierarchies of super- and subdatasets
 


### PR DESCRIPTION
Sadly the table structure doesn't format nicely (i adds a scrollbar instead of linebreaks), so I reformatted it to a glossary. I also added some basic descriptions

![Screenshot from 2022-06-18 11-33-02](https://user-images.githubusercontent.com/29738718/174432304-7625bb88-c81c-460a-a5ec-25b25587ff03.png)
