### PR TITLE
Hook into the datalad-next credential system

### DIFF
--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -23,6 +23,8 @@ from . import (
     DATAVERSE_URL,
 )
 
+DATAVERSE_URL = DATAVERSE_URL or ''
+
 
 @skip_if(cond='testadmin' not in API_TOKENS)
 @with_tempfile

--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 from urllib.parse import quote as urlquote
 
 from datalad.api import (
@@ -10,6 +9,8 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
 )
 from datalad.utils import rmtree
+
+from datalad_next.tests.utils import with_credential
 
 from datalad_dataverse.tests.utils import (
     create_test_dataverse_collection,
@@ -33,14 +34,16 @@ def test_remote(path=None):
     create_test_dataverse_collection(admin_api, 'basetest')
     dspid = create_test_dataverse_dataset(admin_api, 'basetest', 'testds')
     try:
-        with patch.dict('os.environ', {
-                'DATAVERSE_API_TOKEN': API_TOKENS['testadmin']}):
-            _check_remote(ds, dspid)
-
+        _check_remote(ds, dspid)
     finally:
         admin_api.destroy_dataset(dspid)
 
 
+@with_credential(
+    'dataverse',
+    secret=API_TOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+)
 def _check_remote(ds, dspid):
     repo = ds.repo
     repo.call_annex([
@@ -79,14 +82,16 @@ def test_datalad_annex(dspath=None, clonepath=None):
     create_test_dataverse_collection(admin_api, 'basetest')
     dspid = create_test_dataverse_dataset(admin_api, 'basetest', 'testds')
     try:
-        with patch.dict('os.environ', {
-                'DATAVERSE_API_TOKEN': API_TOKENS['testadmin']}):
-            _check_datalad_annex(ds, dspid, clonepath)
-
+        _check_datalad_annex(ds, dspid, clonepath)
     finally:
         admin_api.destroy_dataset(dspid)
 
 
+@with_credential(
+    'dataverse',
+    secret=API_TOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+)
 def _check_datalad_annex(ds, dspid, clonepath):
     repo = ds.repo
     # this is the raw datalad-annex URL, convenience could be added on top

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # we need datalad from the future with pytest for now (will be a datalad-next
 # that depends on datalad 0.17)
 git+https://github.com/datalad/datalad
+git+https://github.com/datalad/datalad-next@pytest


### PR DESCRIPTION
There is not longer a need to pre-deploy a token via an env-var. The
special remote will no query for one automatically and also
store it in a local credential store on successful use. Subsequent
usage no longer requires a re-specification, because the credential
is rediscovered via a "realm" property.