### PR TITLE
Enable test execution against demo.dataverse.org

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -171,9 +171,9 @@ install:
   - sh: echo "$DOCKERHUB_TOKEN $DOCKERHUB_USERNAME"
   - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh $DOCKERHUB_TOKEN $DOCKERHUB_USERNAME; else true; fi;"
   # Show what we got after setup in case something is going wrong:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $TESTS_TOKEN_TESTADMIN $TESTS_TOKEN_USER1\"; else true; fi;"
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $DATAVERSE_TEST_APITOKEN_TESTADMIN $DATAVERSE_TEST_APITOKEN_USER1\"; else true; fi;"
   # Check we got a our dataverse and it's accessible with the admin token:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then curl \"http://localhost:8080/api/search?q=*&type=dataverse&key=${TESTS_TOKEN_TESTADMIN}\"; else true; fi;"
+  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then curl \"http://localhost:8080/api/search?q=*&type=dataverse&key=${DATAVERSE_TEST_APITOKEN_TESTADMIN}\"; else true; fi;"
 
 #before_build:
 #

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -61,4 +61,4 @@ jobs:
         echo "== mount >>"
         mount
         echo "<< mount =="
-        PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v --doctest-modules --cov=datalad_dataverse --pyargs datalad_dataverse
+        DATAVERSE_TEST_APITOKEN_TESTADMIN=${{ secrets.DEMO_DATAVERSE_TOKEN }} PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v --doctest-modules --cov=datalad_dataverse --pyargs datalad_dataverse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,10 +362,10 @@ Several additional notes:
   you'll need `sudo` for `rm`'ing it as well as to see it reported untracked 
   by `git status`.
 
-The CI setup results in two users and a root dataverse being created. A 
-superuser 'testadmin' and a regular user 'user1'. Their API tokens are 
-acccessible for the tests via the environment variables `TESTS_TOKEN_TESTADMIN`
-and `TESTS_TOKEN_USER1` respectively.
+The CI setup results in two users and a root dataverse being created. A
+superuser 'testadmin' and a regular user 'user1'. Their API tokens are
+acccessible for the tests via the environment variables
+`DATAVERSE_TEST_APITOKEN_TESTADMIN` and `DATAVERSE_TEST_APITOKEN_USER1` respectively.
 If you want to see how that is done, so you can reproduce it locally check 
 `setup_docker_dataverse.sh` for how it calls `docker cp` to 
 copy several JSON files and `init_dataverse.sh` into the container and then 

--- a/datalad_dataverse/tests/__init__.py
+++ b/datalad_dataverse/tests/__init__.py
@@ -1,10 +1,38 @@
-import os
-import requests
+import logging
+from os import environ
 
-# Retrieve user API tokens from env vars TESTS_TOKEN_*, where * is the user name
-# (uppercase);
-# This is how the CI setup is currently passing them into the test environment.
-API_TOKENS = {k.split('_')[-1].lower(): v
-              for k, v in os.environ.items() if k.startswith("TESTS_TOKEN")}
+lgr = logging.getLogger('datalad.dataverse')
 
-DATAVERSE_URL = os.environ.get("TESTS_DATAVERSE_BASEURL")
+# Retrieve user API tokens from env vars DATAVERSE_TEST_APITOKEN_*,
+# where * is the user name (uppercase);
+# This is how the docker-based CI setup is currently passing them
+# into the test environment.
+DATAVERSE_TEST_APITOKENS = {
+    k.split('_')[-1].lower(): v
+    for k, v in environ.items()
+    if k.startswith("DATAVERSE_TEST_APITOKEN_")
+}
+
+if 'testadmin' not in DATAVERSE_TEST_APITOKENS:
+    lgr.warning(
+        'Most tests require a dataverse admin token, '
+        'set DATAVERSE_TEST_APITOKEN_TESTADMIN environment variable to specify'
+    )
+
+# the demo deployment of dataverse where anyone can have an account
+# slow, but no setup cost
+DEMO_DATAVERSE_URL = 'https://demo.dataverse.org'
+
+# allow for dataverse test target instance specification
+DATAVERSE_TEST_URL = environ.get("DATAVERSE_TEST_BASEURL", DEMO_DATAVERSE_URL)
+
+# allow for base collection specification, all operations are executed
+# in this collection
+DATAVERSE_TEST_BASECOLLECTION = environ.get(
+    "DATAVERSE_TEST_BASECOLLECTION",
+    # 'demo' is what demo.dataverse uses,
+    # 'root' is for a plain docker-based deployment
+    'demo' if DATAVERSE_TEST_URL == DEMO_DATAVERSE_URL else 'root',
+)
+
+DATAVERSE_TEST_COLLECTION_NAME = 'dataladtester'

--- a/datalad_dataverse/tests/test_create_sibling_dataverse.py
+++ b/datalad_dataverse/tests/test_create_sibling_dataverse.py
@@ -17,8 +17,8 @@ from datalad.distribution.dataset import (
 from datalad_next.tests.utils import with_credential
 
 from datalad_dataverse.tests import (
-    API_TOKENS,
-    DATAVERSE_URL
+    DATAVERSE_TEST_APITOKENS,
+    DATAVERSE_TEST_URL,
 )
 from datalad_dataverse.tests.utils import (
     create_test_dataverse_collection,
@@ -26,30 +26,30 @@ from datalad_dataverse.tests.utils import (
 from datalad_dataverse.utils import get_native_api
 
 
-@skip_if(cond='testadmin' not in API_TOKENS)
+@skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
 @with_tempfile
 @with_tempfile
 def test_basic(path=None, clone_path=None):
     ds = Dataset(path).create()
     (ds.pathobj / 'somefile.txt').write_text('content')
     ds.save()
-    admin_api = get_native_api(DATAVERSE_URL, API_TOKENS['testadmin'])
+    admin_api = get_native_api(DATAVERSE_TEST_URL, DATAVERSE_TEST_APITOKENS['testadmin'])
     create_test_dataverse_collection(admin_api, 'basetest')
     _check_basic_creation(ds, 'basetest', 'testadmin', clone_path)
 
 
 @with_credential(
     'dataverse',
-    secret=API_TOKENS.get('testadmin'),
-    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+    secret=DATAVERSE_TEST_APITOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_basic_creation(ds, collection_alias, user, clone_path):
 
     with patch.dict('os.environ', {
-            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': API_TOKENS[user],
-            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_URL}):
+            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': DATAVERSE_TEST_APITOKENS[user],
+            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_TEST_URL}):
 
-        results = ds.create_sibling_dataverse(url=DATAVERSE_URL,
+        results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
                                               collection=collection_alias,
                                               name='git_remote',
                                               storage_name='special_remote',
@@ -87,30 +87,30 @@ def _check_basic_creation(ds, collection_alias, user, clone_path):
         cloned_ds.get("somefile.txt")
 
 
-@skip_if(cond='testadmin' not in API_TOKENS)
+@skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
 @with_tempfile
 @with_tempfile
 def test_basic_export(path=None, clone_path=None):
     ds = Dataset(path).create()
     (ds.pathobj / 'somefile.txt').write_text('content')
     ds.save()
-    admin_api = get_native_api(DATAVERSE_URL, API_TOKENS['testadmin'])
+    admin_api = get_native_api(DATAVERSE_TEST_URL, DATAVERSE_TEST_APITOKENS['testadmin'])
     create_test_dataverse_collection(admin_api, 'basetest')
     _check_basic_creation(ds, 'basetest', 'testadmin', clone_path)
 
 
 @with_credential(
     'dataverse',
-    secret=API_TOKENS.get('testadmin'),
-    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+    secret=DATAVERSE_TEST_APITOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_basic_export_creation(ds, collection_alias, user, clone_path):
 
     with patch.dict('os.environ', {
-            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': API_TOKENS[user],
-            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_URL}):
+            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': DATAVERSE_TEST_APITOKENS[user],
+            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_TEST_URL}):
 
-        results = ds.create_sibling_dataverse(url=DATAVERSE_URL,
+        results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
                                               collection=collection_alias,
                                               name='git_remote',
                                               storage_name='special_remote',

--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -19,22 +19,20 @@ from datalad_dataverse.tests.utils import (
 from datalad_dataverse.utils import get_native_api
 
 from . import (
-    API_TOKENS,
-    DATAVERSE_URL,
+    DATAVERSE_TEST_APITOKENS,
+    DATAVERSE_TEST_URL,
 )
 
-DATAVERSE_URL = DATAVERSE_URL or ''
 
-
-@skip_if(cond='testadmin' not in API_TOKENS)
+@skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
 @with_tempfile
 def test_remote(path=None):
     ds = Dataset(path).create()
     (ds.pathobj / 'somefile.txt').write_text('content')
     ds.save()
-    admin_api = get_native_api(DATAVERSE_URL, API_TOKENS['testadmin'])
-    create_test_dataverse_collection(admin_api, 'basetest')
-    dspid = create_test_dataverse_dataset(admin_api, 'basetest', 'testds')
+    admin_api = get_native_api(DATAVERSE_TEST_URL, DATAVERSE_TEST_APITOKENS['testadmin'])
+    create_test_dataverse_collection(admin_api, 'dataladtester')
+    dspid = create_test_dataverse_dataset(admin_api, 'dataladtester', 'testds')
     try:
         _check_remote(ds, dspid)
     finally:
@@ -43,14 +41,14 @@ def test_remote(path=None):
 
 @with_credential(
     'dataverse',
-    secret=API_TOKENS.get('testadmin'),
-    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+    secret=DATAVERSE_TEST_APITOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_remote(ds, dspid):
     repo = ds.repo
     repo.call_annex([
         'initremote', 'mydv', 'encryption=none', 'type=external',
-        'externaltype=dataverse', f'url={DATAVERSE_URL}',
+        'externaltype=dataverse', f'url={DATAVERSE_TEST_URL}',
         f'doi={dspid}',
     ])
     # some smoke testing of the git-annex interface
@@ -75,12 +73,12 @@ def _check_remote(ds, dspid):
     ])
 
 
-@skip_if(cond='testadmin' not in API_TOKENS)
+@skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
 @with_tempfile
 @with_tempfile
 def test_datalad_annex(dspath=None, clonepath=None):
     ds = Dataset(dspath).create()
-    admin_api = get_native_api(DATAVERSE_URL, API_TOKENS['testadmin'])
+    admin_api = get_native_api(DATAVERSE_TEST_URL, DATAVERSE_TEST_APITOKENS['testadmin'])
     create_test_dataverse_collection(admin_api, 'basetest')
     dspid = create_test_dataverse_dataset(admin_api, 'basetest', 'testds')
     try:
@@ -91,14 +89,14 @@ def test_datalad_annex(dspath=None, clonepath=None):
 
 @with_credential(
     'dataverse',
-    secret=API_TOKENS.get('testadmin'),
-    realm=f'{DATAVERSE_URL.rstrip("/")}/dataverse',
+    secret=DATAVERSE_TEST_APITOKENS.get('testadmin'),
+    realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_datalad_annex(ds, dspid, clonepath):
     repo = ds.repo
     # this is the raw datalad-annex URL, convenience could be added on top
     git_remote_url = 'datalad-annex::?type=external&externaltype=dataverse&' \
-                     f'url={urlquote(DATAVERSE_URL)}&doi={urlquote(dspid)}&' \
+                     f'url={urlquote(DATAVERSE_TEST_URL)}&doi={urlquote(dspid)}&' \
                      'encryption=none'
 
     repo.call_git(['remote', 'add', 'mydv', git_remote_url])
@@ -108,7 +106,7 @@ def _check_datalad_annex(ds, dspid, clonepath):
         # generic monster URL
         git_remote_url,
         # actual dataset landing page
-        f'{DATAVERSE_URL}/dataset.xhtml?persistentId={dspid}&version=DRAFT',
+        f'{DATAVERSE_TEST_URL}/dataset.xhtml?persistentId={dspid}&version=DRAFT',
     ):
         dsclone = clone(git_remote_url, clonepath)
 

--- a/datalad_dataverse/tests/utils.py
+++ b/datalad_dataverse/tests/utils.py
@@ -4,14 +4,16 @@ from ..create_sibling_dataverse import (
     _create_dv_dataset,
     _get_dv_collection,
 )
+from . import DATAVERSE_TEST_BASECOLLECTION
 
 
-def create_test_dataverse_collection(api, alias, collection='root'):
+def create_test_dataverse_collection(
+        api, alias, collection=DATAVERSE_TEST_BASECOLLECTION):
     dvmeta = Dataverse(dict(
         name="DataLad Test Dataverse",
         alias=alias,
         dataverseContacts=[dict(
-            contactEmail='tester@datalad.org',
+            contactEmail='team@datalad.org',
         )]
     ))
     # create under the 'root' collection
@@ -36,7 +38,7 @@ def create_test_dataverse_dataset(api, collection, name):
         title=name,
         author=[dict(authorName='DataLad')],
         datasetContact=[dict(
-            datasetContactEmail='tester@datalad.org',
+            datasetContactEmail='team@datalad.org',
             datasetContactName='DataLad')],
         dsDescription=[dict(dsDescriptionValue='no description')],
         subject=['Medicine, Health and Life Sciences']
@@ -45,4 +47,3 @@ def create_test_dataverse_dataset(api, collection, name):
     req = _create_dv_dataset(api, col, meta)
     req.raise_for_status()
     return req.json()['data']['persistentId']
-

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -3,9 +3,9 @@ set -e -u
 # This is setting up and launching a docker container with everything needed for
 # our tests to run against this instance.
 # Most importantly with respect to the CI builds, it deposits the API tokens
-# for the users `pete` and `uma` in environment variabes TEST_TOKEN_PETE and
-# TEST_TOKEN_UMA respectively for use from within unit tests. Therefore this
-# script is supposed to be sourced.
+# for the users `pete` and `uma` in environment variabes
+# DATAVERSE_TEST_APITOKEN_PETE and DATAVERSE_TEST_APITOKEN_UMA respectively for use
+# from within unit tests. Therefore this script is supposed to be sourced.
 
 # For administrative tasks at the beginning, we need to execute request from
 # within the container, since the respective API endpoints are only accessible
@@ -50,7 +50,7 @@ done
 set -e
 
 # Dataverse is running, export base URL for test environment
-export TESTS_DATAVERSE_BASEURL="http://localhost:8080"
+export DATAVERSE_TEST_BASEURL="http://localhost:8080"
 
 ### Now, get users and there tokens for use with the tests
 docker_id="$(docker ps -qf name="^dataverse$")"
@@ -78,7 +78,7 @@ if [ -n "${token_admin}" ] && [ "${token_userone}" != "null" ]; then
   adminResp=$(curl -H "X-Dataverse-key:${token_admin}" "http://localhost:8080/api/users/:me")
   if [ $(echo "${adminResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${adminResp}" | jq .data.firstName) == "\"Datalad\"" ]; then
     echo "Token confirmed."
-    export TESTS_TOKEN_TESTADMIN=${token_admin}
+    export DATAVERSE_TEST_APITOKEN_TESTADMIN=${token_admin}
   else
     echo "Failed to use token. User query response: ${adminResp}"
     exit 1
@@ -93,7 +93,7 @@ if [ -n "${token_userone}" ] && [ "${token_userone}" != "null" ]; then
   useroneResp=$(curl -H "X-Dataverse-key:${token_userone}" "http://localhost:8080/api/users/:me")
   if [ $(echo "${useroneResp}" | jq .status) == "\"OK\"" ] && [ $(echo "${useroneResp}" | jq .data.firstName) == "\"Regular\"" ]; then
     echo "Token confirmed."
-    export TESTS_TOKEN_USER1=${token_userone}
+    export DATAVERSE_TEST_APITOKEN_USER1=${token_userone}
   else
     echo "Failed to use token. User query response: ${useroneResp}"
     exit 1

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -3,9 +3,10 @@ set -e -u
 # This is setting up and launching a docker container with everything needed for
 # our tests to run against this instance.
 # Most importantly with respect to the CI builds, it deposits the API tokens
-# for the users `pete` and `uma` in environment variabes
-# DATAVERSE_TEST_APITOKEN_PETE and DATAVERSE_TEST_APITOKEN_UMA respectively for use
-# from within unit tests. Therefore this script is supposed to be sourced.
+# for the users `testadmin` and `user1` in environment variables
+# DATAVERSE_TEST_APITOKEN_TESTADMIN and DATAVERSE_TEST_APITOKEN_USER1
+# respectively for use from within unit tests. Therefore this script is supposed
+# to be sourced.
 
 # For administrative tasks at the beginning, we need to execute request from
 # within the container, since the respective API endpoints are only accessible
@@ -65,7 +66,7 @@ docker cp tools/ci/init_dataverse.sh "${docker_id}:/opt/payara/dvinstall/init_da
 
 
 # setup-users.sh comes with installation. Its output is some text, some JSON and
-# finally two lines giving the tokens for users 'pete' and 'uma'
+# finally two lines giving the tokens for users 'testadmin' and 'user1'
 initresponse=$(docker exec "${docker_id}" /opt/payara/dvinstall/init_dataverse.sh)
 tokens=$(echo "$initresponse" | grep "Token for" | awk '{print $4}')
 


### PR DESCRIPTION
The change makes it possible to run all tests against this common
instance, after specifying a token. The standard user account token
handed out to any user of this instance is a sufficiently capable
admin token.

When no particular dataverse instance URL is specified, all tests
are performed against demo.dataverse.org. This substantially lowers
the barrier for running tests, at the cost of a much slower test
execution.

When no admin token for the tests is given, a prominent warning
with instructions is now given, rather than merely skipping most tests.

The environment variable scheme for configurating the test setup has
been standardized to the following setup:

- DATAVERSE_TEST_URL: Dataverse instance base URL, defaults to
  https://demo.dataverse.org
- DATAVERSE_TEST_BASECOLLECTION: defaults to 'demo' for demo.dataverse.org
  and to 'root' for any other instance URL
- DATAVERSE_TEST_APITOKEN_<USER>: tokens specification for any user

Variable names in the Python code have been changes to match the
environment variable names to prevent confusion and the need to
look up the mapping.

All CI runs where no Docker-based dataverse deployment is available will no automatically run against demo.dataverse.org. Secrets are set up for Docker and Appveyor (with an expiration duration of 12 months).