### PR TITLE
`git annex testremote` may run into path length issues on windows

### DIFF
--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -69,7 +69,10 @@ def _check_remote(ds, dspid):
     ])
     # run git-annex own testsuite
     ds.repo.call_annex([
-        'testremote', '--fast', 'mydv',
+        'testremote',
+        '--backend=MD5E',
+        '--fast',
+        'mydv',
     ])
 
 


### PR DESCRIPTION
Switch to the MD5E backend for the test run (default for other
operations in DataLad) in other to shorten the path length.

Closes datalad/datalad-dataverse#127