### PR TITLE
Use more recent git-annex for appveyor tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,8 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv jq
       # system git-annex is way too old, use better one
-      INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
+      #INSTALL_GITANNEX: git-annex -m deb-url --url https://snapshot.debian.org/archive/debian/20220509T030319Z/pool/main/g/git-annex/git-annex_10.20220504-1_amd64.deb
+      INSTALL_GITANNEX: git-annex -m datalad/git-annex:release
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
       # setting critically needed for launching the dataverse container
       traefikhost: localhost
@@ -77,7 +78,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       # Python version specification is non-standard on windows
       PY: 39-x64
-      INSTALL_GITANNEX: git-annex -m datalad/packages
+      INSTALL_GITANNEX: git-annex -m datalad/git-annex:release
     # MacOS core tests
     - ID: MacP38core
       DTS: datalad_dataverse


### PR DESCRIPTION
Right now the new setup yields 10.20220624 for all platforms.