### PR TITLE
Add linux CI run without docker dataverse

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,6 +71,7 @@ environment:
       # setting critically needed for launching the dataverse container
       DEPLOY_DATAVERSE: 1
       traefikhost: localhost
+      KNOWN2FAIL: 1
     - ID: Ubu20
       DTS: datalad_dataverse
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,16 +61,23 @@ environment:
     # is a need for debugging
 
     # Ubuntu core tests
+    - ID: Ubu20docker
+      DTS: datalad_dataverse
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      INSTALL_SYSPKGS: python3-virtualenv jq
+      # system git-annex is way too old, use better one
+      INSTALL_GITANNEX: git-annex -m datalad/git-annex:release
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      # setting critically needed for launching the dataverse container
+      DEPLOY_DATAVERSE: 1
+      traefikhost: localhost
     - ID: Ubu20
       DTS: datalad_dataverse
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       INSTALL_SYSPKGS: python3-virtualenv jq
       # system git-annex is way too old, use better one
-      #INSTALL_GITANNEX: git-annex -m deb-url --url https://snapshot.debian.org/archive/debian/20220509T030319Z/pool/main/g/git-annex/git-annex_10.20220504-1_amd64.deb
       INSTALL_GITANNEX: git-annex -m datalad/git-annex:release
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-      # setting critically needed for launching the dataverse container
-      traefikhost: localhost
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -168,13 +175,12 @@ install:
   #- sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
   # add location of datalad installer results to PATH
   #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
-  # Set up dataverse docker (Ubuntu build only); sourced since it's exporting the API tokens:
-  - sh: echo "$DOCKERHUB_TOKEN $DOCKERHUB_USERNAME"
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then source tools/ci/setup_docker_dataverse.sh $DOCKERHUB_TOKEN $DOCKERHUB_USERNAME; else true; fi;"
+  # Set up dataverse docker; sourced since it's exporting the API tokens:
+  - sh: "[ -n \"${DEPLOY_DATAVERSE}\" ] && source tools/ci/setup_docker_dataverse.sh $DOCKERHUB_TOKEN $DOCKERHUB_USERNAME || true"
   # Show what we got after setup in case something is going wrong:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then echo \"Received tokens: $DATAVERSE_TEST_APITOKEN_TESTADMIN $DATAVERSE_TEST_APITOKEN_USER1\"; else true; fi;"
+  - sh: "[ -n \"${DEPLOY_DATAVERSE}\" ] && echo \"Received tokens: $DATAVERSE_TEST_APITOKEN_TESTADMIN $DATAVERSE_TEST_APITOKEN_USER1\" || true"
   # Check we got a our dataverse and it's accessible with the admin token:
-  - sh: "if [ \"${APPVEYOR_BUILD_WORKER_IMAGE}\" != \"macOS\" ]; then curl \"http://localhost:8080/api/search?q=*&type=dataverse&key=${DATAVERSE_TEST_APITOKEN_TESTADMIN}\"; else true; fi;"
+  - sh: "[ i-n \"${DEPLOY_DATAVERSE}\" ] && curl \"http://localhost:8080/api/search?q=*&type=dataverse&key=${DATAVERSE_TEST_APITOKEN_TESTADMIN}\" || true"
 
 #before_build:
 #


### PR DESCRIPTION
It makes sense to have this run, because other platforms are tested like
this too, and the docker setup is expensive and fragile (ie., does not
yield a working deployment each time).

Closes #129 