### PR TITLE
De-duplicate, homogenize, and fix API authentication

### DIFF
--- a/datalad_dataverse/tests/test_create_sibling_dataverse.py
+++ b/datalad_dataverse/tests/test_create_sibling_dataverse.py
@@ -1,15 +1,11 @@
-from unittest.mock import patch
-from requests.exceptions import ConnectionError
 from datalad.tests.utils_pytest import (
     assert_in,
-    assert_raises,
     assert_result_count,
     skip_if,
     with_tempfile,
 )
 from datalad.api import (
     clone,
-    create_sibling_dataverse,
 )
 from datalad.distribution.dataset import (
     Dataset,
@@ -44,47 +40,42 @@ def test_basic(path=None, clone_path=None):
     realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_basic_creation(ds, collection_alias, user, clone_path):
+    results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
+                                          collection=collection_alias,
+                                          name='git_remote',
+                                          storage_name='special_remote',
+                                          mode='annex',
+                                          credential='testcred',
+                                          existing='error',
+                                          recursive=False,
+                                          recursion_limit=None,
+                                          metadata=None)
+    assert_result_count(results, 0, status='error')
+    assert_result_count(results, 1,
+                        status='ok',
+                        action='create_sibling_dataverse')
+    assert_result_count(results, 1,
+                        status='ok',
+                        action='create_sibling_dataverse.storage')
+    assert_result_count(results, 2)
 
-    with patch.dict('os.environ', {
-            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': DATAVERSE_TEST_APITOKENS[user],
-            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_TEST_URL}):
+    assert_in('doi', results[0])
+    assert_in('doi', results[1])
 
-        results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
-                                              collection=collection_alias,
-                                              name='git_remote',
-                                              storage_name='special_remote',
-                                              mode='annex',
-                                              credential='testcred',
-                                              existing='error',
-                                              recursive=False,
-                                              recursion_limit=None,
-                                              metadata=None)
-        assert_result_count(results, 0, status='error')
-        assert_result_count(results, 1,
-                            status='ok',
-                            action='create_sibling_dataverse')
-        assert_result_count(results, 1,
-                            status='ok',
-                            action='create_sibling_dataverse.storage')
-        assert_result_count(results, 2)
+    clone_url = [r['url'] for r in results
+                 if r['action'] == "create_sibling_dataverse"][0]
 
-        assert_in('doi', results[0])
-        assert_in('doi', results[1])
+    # push should work now
+    ds.push(to="git_remote")
+    # drop content and retrieve again
+    ds.drop("somefile.txt")
+    ds.get("somefile.txt")
 
-        clone_url = [r['url'] for r in results
-                     if r['action'] == "create_sibling_dataverse"][0]
-
-        # push should work now
-        ds.push(to="git_remote")
-        # drop content and retrieve again
-        ds.drop("somefile.txt")
-        ds.get("somefile.txt")
-
-        # And we should be able to clone
-        cloned_ds = clone(source=clone_url, path=clone_path,
-                          result_xfm='datasets')
-        cloned_ds.repo.enable_remote('special_remote')
-        cloned_ds.get("somefile.txt")
+    # And we should be able to clone
+    cloned_ds = clone(source=clone_url, path=clone_path,
+                      result_xfm='datasets')
+    cloned_ds.repo.enable_remote('special_remote')
+    cloned_ds.get("somefile.txt")
 
 
 @skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
@@ -105,44 +96,39 @@ def test_basic_export(path=None, clone_path=None):
     realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
 def _check_basic_export_creation(ds, collection_alias, user, clone_path):
+    results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
+                                          collection=collection_alias,
+                                          name='git_remote',
+                                          storage_name='special_remote',
+                                          mode='filetree',
+                                          credential='testcred',
+                                          existing='error',
+                                          recursive=False,
+                                          recursion_limit=None,
+                                          metadata=None)
+    assert_result_count(results, 0, status='error')
+    assert_result_count(results, 1,
+                        status='ok',
+                        action='create_sibling_dataverse')
+    assert_result_count(results, 1,
+                        status='ok',
+                        action='create_sibling_dataverse.storage')
+    assert_result_count(results, 2)
 
-    with patch.dict('os.environ', {
-            'DATALAD_CREDENTIAL_TESTCRED_TOKEN': DATAVERSE_TEST_APITOKENS[user],
-            'DATALAD_CREDENTIAL_TESTCRED_REALM': DATAVERSE_TEST_URL}):
+    assert_in('doi', results[0])
+    assert_in('doi', results[1])
 
-        results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
-                                              collection=collection_alias,
-                                              name='git_remote',
-                                              storage_name='special_remote',
-                                              mode='filetree',
-                                              credential='testcred',
-                                              existing='error',
-                                              recursive=False,
-                                              recursion_limit=None,
-                                              metadata=None)
-        assert_result_count(results, 0, status='error')
-        assert_result_count(results, 1,
-                            status='ok',
-                            action='create_sibling_dataverse')
-        assert_result_count(results, 1,
-                            status='ok',
-                            action='create_sibling_dataverse.storage')
-        assert_result_count(results, 2)
+    clone_url = [r['url'] for r in results
+                 if r['action'] == "create_sibling_dataverse"][0]
 
-        assert_in('doi', results[0])
-        assert_in('doi', results[1])
+    # push should work now
+    ds.push(to="git_remote")
+    # drop content and retrieve again
+    ds.drop("somefile.txt")
+    ds.get("somefile.txt")
 
-        clone_url = [r['url'] for r in results
-                     if r['action'] == "create_sibling_dataverse"][0]
-
-        # push should work now
-        ds.push(to="git_remote")
-        # drop content and retrieve again
-        ds.drop("somefile.txt")
-        ds.get("somefile.txt")
-
-        # And we should be able to clone
-        cloned_ds = clone(source=clone_url, path=clone_path,
-                          result_xfm='datasets')
-        cloned_ds.repo.enable_remote('special_remote')
-        cloned_ds.get("somefile.txt")
+    # And we should be able to clone
+    cloned_ds = clone(source=clone_url, path=clone_path,
+                      result_xfm='datasets')
+    cloned_ds.repo.enable_remote('special_remote')
+    cloned_ds.get("somefile.txt")

--- a/datalad_dataverse/utils.py
+++ b/datalad_dataverse/utils.py
@@ -2,6 +2,8 @@ import re
 
 from pyDataverse.api import NativeApi
 
+from datalad_next.utils import update_specialremote_credential
+
 # This cannot currently be queried for via public API. See gh-27
 DATASET_SUBJECTS = [
  'Agricultural Sciences',
@@ -28,6 +30,100 @@ def get_native_api(baseurl, token):
       The pyDataverse API wrapper
     """
     return NativeApi(baseurl, token)
+
+
+def get_api(url, credman, credential_name=None):
+    """Get authenticated API access to a dataverse instance
+
+    Parameters
+    ----------
+    url: str
+      Base URL of the target dataverse deployment.
+    credman: CredentialManager
+      For querying credentials based on a given name, or an authentication
+      realm determined from the specified URL
+    credential_name: str, optional
+      If given, the name will be used to identify a credential for API
+      authentication. If that fails, or no name is given, an attempt to
+      identify a credential based on the dataverse URL will be made.
+
+    Returns
+    -------
+    NativeApi
+      The pyDataverse API wrapper. The token used for authentication is
+      available via the `.api_token` accessor.
+
+    Raises
+    ------
+    LookupError
+      When no credential could be determined, either by name or by realm.
+
+    HTTPError
+      If making a simple API version request using the determined credential
+      fails, the exception from `requests.raise_for_status()` is passed
+      through.
+    """
+    # TODO the below is almost literally taken from
+    # the datalad-annex:: implementation in datalad-next
+    # this could become a common helper
+    credential_realm = url.rstrip('/') + '/dataverse'
+    cred = None
+    if credential_name:
+        # we can ask blindly first, caller seems to know what to do
+        cred = credman.get(
+            name=credential_name,
+            # give to make legacy credentials accessible
+            _type_hint='token',
+        )
+    if not cred:
+        creds = credman.query(
+            _sortby='last-used',
+            realm=credential_realm,
+        )
+        if creds:
+            credential_name, cred = creds[0]
+    if not cred:
+        # credential query failed too, enable manual entry
+        cred = credman.get(
+            # this might still be None
+            name=credential_name,
+            _type_hint='token',
+            _prompt=f'A dataverse API token is required for access',
+            # inject anything we already know to make sure we store it
+            # at the very end, and can use it for discovery next time
+            realm=credential_realm,
+        )
+    if 'secret' not in cred:
+        raise LookupError('No suitable credential found')
+
+    # connect to dataverse instance
+    api = get_native_api(
+        baseurl=url,
+        token=cred['secret'],
+    )
+    # make one cheap request to ensure that the token is
+    # in-principle working -- we won't be able to verify all necessary
+    # permissions for all possible operations anyways
+    try:
+        api.get_info_version().raise_for_status()
+    except Exception as e:
+        raise ValueError from e
+
+    update_specialremote_credential(
+        'dataverse',
+        credman,
+        credential_name,
+        cred,
+        credtype_hint='token',
+        duplicate_hint=
+        'Specify a credential name via the dlacredential= '
+        'special remote parameter, and/or configure a credential '
+        'with the datalad-credentials command{}'.format(
+            f' with a `realm={cred["realm"]}` property'
+            if 'realm' in cred else ''),
+    )
+    # store for reuse with data access API
+    return api
 
 
 def format_doi(doi_in: str) -> str:


### PR DESCRIPTION
Previously, two different implementations were used for the special
remote and for the `create-sibling-dataverse` command.

This change consolidates both implementation on a single, improved one:
`datalad_dataverse.utils.get_api()`. This implies the following changes:

- `create-sibling-dataverse` now stores entered credentials, after
  they were tested. Closes datalad/datalad-dataverse#115
  Closes datalad/datalad-dataverse#113
- Credential lookup failure and authentication failure are now
  communicated as two different, documented exceptions.
- Test implementations for `create-sibling-dataverse` have been
  simplified, no custom environment patching is needed due to
  proper credential store usage.
- `create-sibling-dataverse` implementation was simplified, because
  no credentials need to be passed around.