### PR TITLE
CI: Turn dockerhub login from separate job into step within existing job

### DIFF
--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -3,20 +3,15 @@ name: crippled-filesystems
 on: [pull_request]
 
 jobs:
-  login:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
   test:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Set up system
       shell: bash
       run: |


### PR DESCRIPTION
In response to https://github.com/datalad/datalad-dataverse/pull/147#issuecomment-1214849391