### PR TITLE
BF: Provide sibling name default

### DIFF
--- a/datalad_dataverse/create_sibling_dataverse.py
+++ b/datalad_dataverse/create_sibling_dataverse.py
@@ -215,7 +215,7 @@ class CreateSiblingDataverse(Interface):
             url: str,
             *,
             dataset: Optional[Union[str, Dataset]] = None,
-            name: Optional[str] = None,
+            name: Optional[str] = 'dataverse',
             storage_name: Optional[str] = None,
             mode: str = 'annex',
             credential: Optional[str] = None,


### PR DESCRIPTION
Similar to how other create-sibling-* commands provide sibling name defaults,
create-sibling-dataverse now calls git-part siblings 'dataverse' by default
unless instructed otherwise. Fixes #140

This will need at least a smoke test, but since the create-sibling-dataverse tests are currently disabled I didn't add one yet.