### PR TITLE
Rewrite special remote

### DIFF
--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -1,15 +1,21 @@
-import os
 import re
+import sys
 
-from annexremote import ExportRemote
-
+from annexremote import (
+    ExportRemote,
+    UnsupportedRequest,
+)
+from collections import namedtuple
 from pyDataverse.api import DataAccessApi
 from pyDataverse.models import Datafile
-
 from requests import delete
 from requests.auth import HTTPBasicAuth
+from shutil import which
 
-from datalad.customremotes import SpecialRemote
+from datalad.customremotes import (
+    RemoteError,
+    SpecialRemote
+)
 from datalad.customremotes.main import main as super_main
 from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import Path
@@ -21,8 +27,21 @@ from datalad_dataverse.utils import (
     format_doi,
 )
 
-
 LEADING_DOT_REPLACEMENT = "_._"
+DATALAD_ANNEX_SPECIAL_KEYS = ["XDLRA--refs", "XDLRA--repo-export"]
+
+# Object to hold what's on dataverse's end for a given database id.
+# We need the paths in the latest version (if the id is part of that) in order
+# to know whether we need to replace rather than just upload a file, and we need
+# to know whether an id is released, since that implies we can't replace it
+# (but we could change the metadata, right?) and we can't actually delete it.
+# The latter meaning: It can be removed from the new DRAFT version, but it's
+# still available via its id from an older version of the dataverse dataset.
+# This namedtuple is meant to be the value type of a dict with ids as its keys:
+FileIdRecord = namedtuple("FileIdRecord", "path, is_released")
+
+# Needed to determine whether RENAMEEXPORT can be considered implemented.
+CURL_EXISTS = which('curl') is not None
 
 
 def mangle_directory_names(path):
@@ -41,13 +60,20 @@ def mangle_directory_names(path):
     else:
         filename = None
 
-    dataverse_path = \
-        Path((LEADING_DOT_REPLACEMENT + local_path.parts[0][1:])
-             if local_path.parts[0].startswith('.') else local_path.parts[0]
-             )
-    for pt in local_path.parts[1:]:
-        dataverse_path /= (LEADING_DOT_REPLACEMENT + pt[1:]) \
-            if pt.startswith('.') else pt
+    if local_path == Path("."):
+        # `path` either is '.' or a file in '.'.
+        # Nothing to do: '.' has no representation on dataverse anyway.
+        # Note also, that Path(".").parts is an empty tuple for some reason,
+        # hence the code block below must be protected against this case.
+        dataverse_path = local_path
+    else:
+        dataverse_path = \
+            Path((LEADING_DOT_REPLACEMENT + local_path.parts[0][1:])
+                 if local_path.parts[0].startswith('.') else local_path.parts[0]
+                 )
+        for pt in local_path.parts[1:]:
+            dataverse_path /= (LEADING_DOT_REPLACEMENT + pt[1:]) \
+                if pt.startswith('.') else pt
 
     # re-append file if necessary
     if filename:
@@ -68,7 +94,13 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         self._doi = None
         self._url = None
         self._api = None
+        self._data_access_api = None
         self._token = None
+        self._old_dataset_versions = None
+        self._dataset_latest = None
+        self._files_old = None
+        self._files_latest = None
+        self.is_draft = None
 
     def initremote(self):
         """
@@ -78,7 +110,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # check if instance is readable and authenticated
         resp = self.api.get_info_version()
         if resp.json()['status'] != 'OK':
-            raise RuntimeError(f'Cannot connect to dataverse instance (status: {resp.json()["status"]})')
+            raise RuntimeError(f'Cannot connect to dataverse instance '
+                               f'(status: {resp.json()["status"]})')
 
         # check if project with specified doi exists
         dv_ds = self.api.get_dataset(identifier=self.doi)
@@ -127,132 +160,495 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
         return self._api
 
+    @property
+    def data_access_api(self):
+        if self._data_access_api is None:
+            self._data_access_api = DataAccessApi(
+                base_url=self.url,
+                # this relies on having established the NativeApi in prepare()
+                api_token=self._token,
+                )
+        return self._data_access_api
+
+    @property
+    def old_dataset_versions(self):
+        """Full JSON record of the dataverse dataset.
+
+        This is requested once when relevant to look for a key that is not
+        present in the latest version of the dataverse dataset. In such case,
+        `files_old` is build from it.
+        """
+
+        if self._old_dataset_versions is None:
+            # This delivers a full record of all known versions of this dataset.
+            # Hence, the file lists in the version entries may contain
+            # duplicates (unchanged files across versions).
+            self.message("Request all dataset versions", type='debug')
+            versions = self.api.get_dataset_versions(self.doi)
+            versions.raise_for_status()
+
+            self._old_dataset_versions = versions.json()['data']
+            # Expected structure in self._dataset is a list of (version-)
+            # dictionaries, which should have a field 'files'. This again is a
+            # list of dicts like this:
+            #  {'description': '',
+            #   'label': 'third_file.md',
+            #   'restricted': False,
+            #   'directoryLabel': 'subdir2',
+            #   'version': 1,
+            #   'datasetVersionId': 72,
+            #   'dataFile': {'id': 682,
+            #   'persistentId': '',
+            #   'pidURL': '',
+            #   'filename': 'third_file.md',
+            #   'contentType': 'text/plain',
+            #   'filesize': 9,
+            #   'description': '',
+            #   'storageIdentifier': 'local://1821bc70e68-c3c9dedcfce6',
+            #   'rootDataFileId': -1,
+            #   'md5': 'd8d77109f4a24efc3bd53d7cabb7ee35',
+            #   'checksum': {'type': 'MD5',
+            #                'value': 'd8d77109f4a24efc3bd53d7cabb7ee35'},
+            #   'creationDate': '2022-07-20'}
+
+            # Sort by version, so we can rely on the last entry to refer to the
+            # latest version.
+            # Note, that ('versionNumber', 'versionMinorNumber', 'versionState')
+            # would look like this:
+            # (None, None, 'DRAFT'), (2, 0, 'RELEASED'), (1, 0, 'RELEASED')
+            # and we need a possible DRAFT to have the greatest key WRT sorting.
+            self._old_dataset_versions.sort(
+                key=lambda v: (v.get('versionNumber') or sys.maxsize,
+                               v.get('versionMinorNumber') or sys.maxsize),
+                reverse=False)
+            # Remove "latest" - we already have that
+            self._old_dataset_versions = self._old_dataset_versions[:-1]
+
+        return self._old_dataset_versions
+
+    @property
+    def dataset_latest(self):
+        """JSON representation on the latest version of the dataverse dataset.
+
+        This is used to initialize `files_latest` and only requested once.
+        """
+
+        if self._dataset_latest is None:
+            self.message("Request latest dataset version", type='debug')
+            dataset = self.api.get_dataset(identifier=self.doi,
+                                           version=":latest")
+            dataset.raise_for_status()
+            self._dataset_latest = dataset.json()['data']['latestVersion']
+        return self._dataset_latest
+
+    @property
+    def files_old(self):
+        """Files available from older dataverse dataset versions.
+
+        For quick lookup and deduplication, this is a dict {id: FileIdRecord}
+        """
+
+        if self._files_old is None:
+            self._files_old = {f['dataFile']['id']: FileIdRecord(
+                Path(f.get('directoryLabel', '')) / f['dataFile']['filename'],
+                True  # older versions are always released
+                )
+                for file_lists in [(version['files'], version['versionState'])
+                                   for version in self.old_dataset_versions]
+                for f in file_lists[0]}
+
+        return self._files_old
+
+    @property
+    def files_latest(self):
+        """Cache of files in the latest version of the dataverse dataset.
+
+        This refers to the DRAFT version (if there is any) or the latest
+        published version otherwise. That's the version pushes go into. Hence,
+        this is needed to determine whether we need and can replace/remove a
+        file, while the complete list in `self.files_old` is relevant for key
+        retrieval of keys that are not present in the latest version anymore.
+
+        Note, that whie initially we may not be in a draft, we are as soon as we
+        change things (upload/repace/remove/rename). We keep track of those
+        changes herein w/o rerequesting the new state.
+        """
+
+        if self._files_latest is None:
+            # Latest version in self.dataset is first entry.
+            self._files_latest = {f['dataFile']['id']: FileIdRecord(
+                Path(f.get('directoryLabel', '')) / f['dataFile']['filename'],
+                self.dataset_latest['versionState'] == "RELEASED"
+                )
+                for f in self.dataset_latest['files']}
+
+        return self._files_latest
+
+    def remove_from_filelist(self, id):
+        """Update self.files_latest after removal"""
+        # make sure this property actually exists before assigning:
+        # (This may happen when git-annex-export decides to remove a key w/o
+        # even considering checkpresent)
+        self.files_latest
+        self._files_latest.pop(id, None)
+
+    def add_to_filelist(self, d):
+        """Update self.files_latest after upload
+
+        d: dict
+          dataverse description dict of the file; this dict is in the list
+          'data.files' of the response to a successful upload
+        """
+        # make sure this property actually exists before assigning:
+        # (This may happen on `git-annex-copy --fast`)
+        self.files_latest
+
+        self._files_latest[d['dataFile']['id']] = FileIdRecord(
+            Path(d.get('directoryLabel', '')) / d['dataFile']['filename'],
+            False  # We just added - it can't be released
+        )
+
+    def get_stored_id(self, key):
+        """Get the dataverse database id from the git-annex branch
+
+        This is using the getstate/setstate special remote feature. Hence, a
+        stored id only exists, if the key was put to the dataverse instance by
+        this special remote.
+
+        Parameters
+        ----------
+        key: str
+            annex key to retrieve the id for
+
+        Returns
+        -------
+        int or None
+        """
+        stored_id = self.annex.getstate(key)
+        if stored_id == "":
+            return None
+        else:
+            return int(stored_id)
+
+    def set_stored_id(self, key, id):
+        """Store a dataverse database id for a given key
+
+        Parameters
+        ----------
+        key: str
+            annex key to store the id for
+        id: int or str
+            dataverse database id for `key`. Empty string to unset.
+        """
+        self.annex.setstate(key, str(id))
+
+    def get_id_by_path(self, path, latest_only=True):
+        """Get the id of a dataverse file, that matches a given `Path` in the
+        dataverse dataset.
+
+        Parameters
+        ----------
+        path: Path
+        latest_only: bool
+            Whether to only consider the latest version on dataverse. If
+            `False`, matching against older versions will only be performed
+            when there was no match in the latest version (implies that an
+            additional request may be performed)
+
+        Returns
+        -------
+        int or None
+        """
+        existing_id = [i for i, f in self.files_latest.items()
+                       if f.path == path]
+        if not latest_only and not existing_id:
+            existing_id = [i for i, f in self.files_old.items()
+                           if f.path == path]
+        return existing_id[0] if existing_id else None
+
     def prepare(self):
         # trigger API instance in order to get possibly auth/connection errors
         # right away
         self.api
 
     def checkpresent(self, key):
-        dataset = self.api.get_dataset(identifier=self.doi)
-
-        datafiles = dataset.json()['data']['latestVersion']['files']
-        if next((item for item in datafiles if item['dataFile']['filename'] == key), None):
-            return True
+        stored_id = self.get_stored_id(key)
+        if stored_id is not None:
+            # First, check latest version. Second, check older versions.
+            # This is to avoid requesting the full file list unless necessary.
+            return stored_id in self.files_latest.keys() or \
+                   stored_id in self.files_old.keys()
         else:
-            return False
+            # We do not have an ID on record for this key.
+            # Fall back to filename matching for two reasons:
+            # 1. We have to deal with the special keys of the datalad-annex
+            #    git-remote-helper. They must be matched by name, since the
+            #    throwaway repo using them doesn't have a relevant git-annex
+            #    branch with an ID record (especially when cloning via the
+            #    git-remote-helper)
+            # 2. We are in "regular annex mode" here - keys are stored under
+            #    their name. Falling back to name matching allows to recover
+            #    data, despite a lost or not generated id record for it. For
+            #    example on could have uploaded lots of data via git-annex-copy,
+            #    but failed to push the git-annex branch somewhere.
+            return Path(key) in [f.path for f in self.files_latest.values()] or \
+                   Path(key) in [f.path for f in self.files_old.values()]
 
     def checkpresentexport(self, key, remote_file):
+        # In export mode, we need to fix remote paths:
         remote_file = mangle_directory_names(remote_file)
-        remote_dir = str(remote_file.parent)
-        dataset = self.api.get_dataset(identifier=self.doi)
-        datafiles = dataset.json()['data']['latestVersion']['files']
 
-        for item in datafiles:
-            if 'directoryLabel' in item:
-                hit_dir = item['directoryLabel'] == remote_dir
+        # In opposition to checkpresent (annex mode), we fall back to path
+        # matching for the special keys of the datalad-annex
+        # git-remote-helper only. For accessing other files w/o an id record,
+        # that are present on dataverse, importtree is the way to go.
+        if key in DATALAD_ANNEX_SPECIAL_KEYS:
+            return remote_file in [f.path for f in self.files_latest.values()]
+        else:
+            stored_id = self.get_stored_id(key)
+            if stored_id is not None:
+                # Only check latest version in export mode. Doesn't currently
+                # work for keys from older versions, since annex fails to even
+                # try. See https://github.com/datalad/datalad-dataverse/issues/146#issuecomment-1214409351.
+                return stored_id in self.files_latest.keys()
             else:
-                hit_dir = True
+                # We do not have an ID on record for this key and we can't trust
+                # matching paths in export mode in the general case.
+                return False
 
-            hit_file = item['dataFile']['filename'] == remote_file.name
-            if hit_file and hit_dir:
-                return True
-        return False
+    def _upload_file(self, datafile, key, local_file, remote_file):
+        """helper for both transfer-store methods"""
+        # If the remote path already exists, we need to replace rather than
+        # upload the file, since otherwise dataverse would rename the file on
+        # its end. However, this only concerns the latest version of the dataset
+        # (which is what we are pushing into)!
+        replace_id = self.get_id_by_path(remote_file)
+        if replace_id is not None:
+            self.message(f"Replacing {remote_file} ...", type='debug')
+            response = self.api.replace_datafile(identifier=replace_id,
+                                                 filename=local_file,
+                                                 json_str=datafile.json(),
+                                                 is_filepid=False)
+        else:
+            self.message(f"Uploading {remote_file} ...", type='debug')
+            response = self.api.upload_datafile(identifier=self.doi,
+                                                filename=local_file,
+                                                json_str=datafile.json())
 
-    def transfer_store(self, key, local_file, datafile=None):
-        ds_pid = self.doi
-        if datafile is None:
-            datafile = Datafile()
-            datafile.set({'filename': key, 'label': key})
-        datafile.set({'pid': ds_pid})
-        
-        resp = self.api.upload_datafile(identifier=ds_pid, filename=local_file, json_str=datafile.json())
-        resp.raise_for_status()
+        if response.status_code == 400 and \
+                response.json()['status'] == "ERROR" and \
+                "duplicate content" in response.json()['message']:
+            # Ignore this one for now.
+            # TODO: This needs better handling. Currently, this happens in
+            # git-annex-testremote ("store when already present").
+            # Generally it's kinda fine, but we'd better figure this out more
+            # reliably. Note, that we have to deal with annex keys, which are
+            # not hash based (for example the special keys fo datalad-annex
+            # git-remote-helper).
+            # Hence, having the key on the remote end, doesn't mean it's
+            # identical. So, we can't catch it beforehand this way.
+            self.message(f"Failed to upload {key}, since dataverse says we are "
+                         f"replacing with duplicate content.", type='debug')
+            return  # nothing changed and nothing needs to be done
+        else:
+            response.raise_for_status()
 
-    def transferexport_store(self, key, local_file, remote_file):
-        remote_file = str(mangle_directory_names(remote_file))
+        # Success.
 
-        remote_dir = os.path.dirname(remote_file)
-        # TODO: Pretty sure there's similar or identical restrictions to
-        # filenames; Double-check and be clear here.
-        if re.search(pattern=r'[^a-z0-9_\-.\\/\ ]', string=remote_dir, flags=re.ASCII | re.IGNORECASE):
-            self.annex.error(f"Invalid character in directory name of {remote_file}."
-                             f"Valid characters are a-Z, 0-9, '_', '-', '.', '\\', '/' and ' ' (white space).")
+        # If we replaced, `replaced_id` is not part of the latest version
+        # anymore.
+        if replace_id is not None:
+            self.remove_from_filelist(re)
+            # In case of replace we need to figure whether the replaced
+            # ID was part of a DRAFT version only. In that case it's gone and
+            # we'd need to remove the ID record. Otherwise, it's still retrieval
+            # from an old, published version.
+            # Note, that this would potentially trigger the request of the full
+            # file list (`self.files_old`).
+            if not (self.files_latest[replace_id].is_released or
+                    replace_id in self.files_old.keys()):
+                self.set_stored_id(key, "")
 
-        datafile = Datafile()
-        datafile.set({'filename': remote_file,
-                      'directoryLabel': remote_dir,
-                      'label': os.path.basename(remote_file)})
-        self.transfer_store(key=remote_file, local_file=local_file, datafile=datafile)
+        uploaded_file = response.json()['data']['files'][0]
+        # update cache:
+        self.add_to_filelist(uploaded_file)
+        # remember dataverse's database id for this key
+        self.set_stored_id(key, uploaded_file['dataFile']['id'])
 
-    def transfer_retrieve(self, key, file):
-        data_api = DataAccessApi(
-            base_url=self.url,
-            # this relies on having established the NativeApi in prepare()
-            api_token=self._token,
-        )
-        dataset = self.api.get_dataset(identifier=self.doi)
-
-        # http error handling
-        dataset.raise_for_status()
-
-        files_list = dataset.json()['data']['latestVersion']['files']
-
-        # find the file we want to download
-        file_id = None
-        for current_file in files_list:
-            filename = current_file['dataFile']['filename']
-            if filename == key:
-                file_id = current_file['dataFile']['id']
-                break
-
-        # error handling if file was not found on remote
-        if file_id is None:
-            raise ValueError(f"File {key} is unknown to remote")
-
-        response = data_api.get_datafile(file_id)
+    def _download_file(self, file_id, local_file):
+        """helper for both transfer-retrieve methods"""
+        response = self.data_access_api.get_datafile(file_id)
         # http error handling
         response.raise_for_status()
-        with open(file, "wb") as f:
+        with open(local_file, "wb") as f:
             f.write(response.content)
 
-    def transferexport_retrieve(self, key, local_file, remote_file):
-        remote_file = str(mangle_directory_names(remote_file))
+    def _remove_file(self, key, remote_file):
+        """helper for both remove methods"""
+        stored_id = self.get_stored_id(key)
+        rm_id = None
+        if stored_id is not None:
+            rm_id = stored_id
+            if rm_id not in self.files_latest.keys():
+                # We can't remove from older (hence published) versions.
+                return
+        elif key in DATALAD_ANNEX_SPECIAL_KEYS:
+            # In opposition to `checkpresent` and `transfer_retrieve`, we only
+            # use path matching for the datalad-annex special keys in `remove`
+            # in both modes ("regular annex" and export).
+            # While it's fine to try to use remote files named for an annex key
+            # despite not having its id on record, we have to assume it's been
+            # put there by other means and a destructive operation should be
+            # taken care of by those same means.
+            rm_id = self.get_id_by_path(remote_file)
 
-        self.transfer_retrieve(key=remote_file, file=local_file)
-
-    def remove(self, key):
-        # get the dataset and a list of all files
-        dataset = self.api.get_dataset(identifier=self.doi)
-        # http error handling
-        dataset.raise_for_status()
-        files_list = dataset.json()['data']['latestVersion']['files']
-
-        file_id = None
-
-        # find the file we want to delete
-        for file in files_list:
-            filename = file['dataFile']['filename']
-            if filename == key:
-                file_id = file['dataFile']['id']
-                break
-
-        if file_id is None:
-            # the key is not present, we can return, protocol
-            # declare this condition to be a successful removal
+        if rm_id is None:
+            # We didn't find anything to remove. That should be fine and
+            # considered a successful removal by git-annex.
             return
 
-        # delete the file
         status = delete(
             f'{self.url}/dvn/api/data-deposit/v1.1/swordv2/'
-            f'edit-media/file/{file_id}',
+            f'edit-media/file/{rm_id}',
             # this relies on having established the NativeApi in prepare()
             auth=HTTPBasicAuth(self._token, ''))
         # http error handling
         status.raise_for_status()
+        # We need to figure whether the removed ID was part of a released
+        # version. In that case it's still retrievable from an old, published
+        # version.
+        # Note, that this would potentially trigger the request of the full
+        # file list (`self.files_old`).
+        if not (self.files_latest[rm_id].is_released or
+                rm_id in self.files_old.keys()):
+            self.message(f"Unset stored id for {key}", type='debug')
+            self.set_stored_id(key, "")
+        else:
+            # Despite not actually deleting from the dataverse database, we
+            # currently loose access to the old key (in export mode, that is),
+            # because annex registers a successful REMOVEEXPORT and there seems
+            # to be no way to make annex even try to run a CHECKPRESENT(-EXPORT)
+            # on an export remote in such case. get, fsck, checkpresentkey -
+            # none of them would do.
+            # TODO: We could try to setpresenturl for the not-really-removed
+            # file, if it has a persistent URL (should be findable in
+            # self.old_dataset_versions) or even via api/access/datafile/811.
+            # However, that depends on permissions, etc., so not clear it's
+            # useful or desireable to always do that.
+            # Otherwise not seeing a solution ATM. See https://github.com/datalad/datalad-dataverse/issues/146#issuecomment-1214409351
+            pass
+        # This ID is not part of the latest version anymore.
+        self.remove_from_filelist(rm_id)
+
+    def transfer_store(self, key, local_file):
+        datafile = Datafile()
+        datafile.set({'filename': key, 'label': key})
+        datafile.set({'pid': self.doi})
+
+        self._upload_file(datafile=datafile,
+                          key=key,
+                          local_file=local_file,
+                          remote_file=Path(key))
+
+    def transferexport_store(self, key, local_file, remote_file):
+        remote_file = mangle_directory_names(remote_file)
+        # TODO: See
+        # https://github.com/datalad/datalad-dataverse/issues/83#issuecomment-1214406034
+        if re.search(pattern=r'[^a-z0-9_\-.\\/\ ]',
+                     string=str(remote_file.parent),
+                     flags=re.ASCII | re.IGNORECASE):
+            self.annex.error(f"Invalid character in directory name of "
+                             f"{str(remote_file)}. Valid characters are a-Z, "
+                             f"0-9, '_', '-', '.', '\\', '/' and ' ' "
+                             f"(white space).")
+
+        datafile = Datafile()
+        datafile.set({'filename': remote_file.name,
+                      'directoryLabel': str(remote_file.parent),
+                      'label': remote_file.name,
+                      'pid': self.doi})
+
+        self._upload_file(datafile, key, local_file, remote_file)
+
+    def transfer_retrieve(self, key, file):
+        stored_id = self.get_stored_id(key)
+        if stored_id is not None:
+            file_id = stored_id
+        else:
+            # Like in `self.checkpresent`, we fall back to path matching.
+            # Delayed checking for availability from old versions is included.
+            file_id = self.get_id_by_path(Path(key), latest_only=False)
+            if file_id is None:
+                raise RemoteError(f"Key {key} unavailable")
+
+        self._download_file(file_id, file)
+
+    def transferexport_retrieve(self, key, local_file, remote_file):
+        # In export mode, we need to fix remote paths:
+        remote_file = mangle_directory_names(remote_file)
+        stored_id = self.get_stored_id(key)
+        file_id = None
+        if stored_id is not None:
+            file_id = stored_id
+        else:
+            # Like in `self.checkpresentexport`, we fall back to path matching
+            # for special keys only in export mode.
+            if key in DATALAD_ANNEX_SPECIAL_KEYS:
+                file_id = self.get_id_by_path(remote_file)
+            if file_id is None:
+                raise RemoteError(f"Key {key} unavailable")
+
+        self._download_file(file_id, local_file)
+
+    def remove(self, key):
+        remote_file = Path(key)
+        self._remove_file(key, remote_file)
 
     def removeexport(self, key, remote_file):
-        remote_file = str(mangle_directory_names(remote_file))
-        return self.remove(key=remote_file)
+        remote_file = mangle_directory_names(remote_file)
+        self._remove_file(key, remote_file)
+
+    def renameexport(self, key, filename, new_filename):
+        """Moves an exported file.
+
+        If implemented, this is called by annex-export when a file was moved.
+        Otherwise annex calls removeexport + transferexport_store, which doesn't
+        scale well performance-wise.
+        """
+        # Note: In opposition to other API methods, `update_datafile_metadata`
+        # is running `curl` in a subprocess. No idea why. As a consequence, this
+        # depends on the availability of curl and the return value is not (as in
+        # all other cases) a `requests.Response` object, but a
+        # `subprocess.CompletedProcess`.
+        # This apparently is planned to be changed in pydataverse 0.4.0:
+        # https://github.com/gdcc/pyDataverse/issues/88
+        if not CURL_EXISTS:
+            raise UnsupportedRequest()
+
+        filename = mangle_directory_names(filename)
+        new_filename = mangle_directory_names(new_filename)
+
+        stored_id = self.get_stored_id(key)
+        file_id = None
+        if stored_id is None:
+            if key in DATALAD_ANNEX_SPECIAL_KEYS:
+                file_id = self.get_id_by_path(filename)
+        else:
+            file_id = stored_id
+        if file_id is None:
+            raise RemoteError(f"{key} not available for renaming")
+
+        datafile = Datafile()
+        datafile.set({'filename': new_filename.name,
+                      'directoryLabel': str(new_filename.parent),
+                      'label': new_filename.name,
+                      'pid': self.doi})
+
+        proc = self.api.update_datafile_metadata(file_id,
+                                                 json_str=datafile.json(),
+                                                 is_filepid=False)
+        if proc.returncode:
+            raise RemoteError(f"Renaming failed: {proc.stderr}")
 
 
 def main():
@@ -260,6 +656,5 @@ def main():
     super_main(
         cls=DataverseRemote,
         remote_name='dataverse',
-        description=\
-        "transport file content to and from a Dataverse dataset",
-)
+        description="transport file content to and from a Dataverse dataset",
+    )

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -142,8 +142,21 @@ class DataverseRemote(ExportRemote, SpecialRemote):
             return False
 
     def checkpresentexport(self, key, remote_file):
-        remote_file = str(mangle_directory_names(remote_file))
-        return self.checkpresent(key=remote_file)
+        remote_file = mangle_directory_names(remote_file)
+        remote_dir = str(remote_file.parent)
+        dataset = self.api.get_dataset(identifier=self.doi)
+        datafiles = dataset.json()['data']['latestVersion']['files']
+
+        for item in datafiles:
+            if 'directoryLabel' in item:
+                hit_dir = item['directoryLabel'] == remote_dir
+            else:
+                hit_dir = True
+
+            hit_file = item['dataFile']['filename'] == remote_file.name
+            if hit_file and hit_dir:
+                return True
+        return False
 
     def transfer_store(self, key, local_file, datafile=None):
         ds_pid = self.doi

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -83,6 +83,107 @@ def mangle_directory_names(path):
 
 
 class DataverseRemote(ExportRemote, SpecialRemote):
+    """Special remote to interface dataverse datasets.
+
+    There are two modes of operation:
+    - "Regular" special remote (configured with exporttree=false; default),
+      where a flat ist of annex keys is put into that dataverse dataset and
+    - export remote (configured with exporttree=yes), where the actual worktree
+      is put into the dataverse dataset
+
+    Dataverse
+    ---------
+
+    Dataverse datasets come with their own versioning. A version is created upon
+    publishing a draft version. When a change is pushed, it is altering an
+    already existing draft version or - if none existed - the push (implicitly)
+    creates a new draft version. Publishing is not part of this special remotes
+    operations as it has no means to "discover" that this should happen (it only
+    communicates with git-annex on a per-file basis and does not even know what
+    annex command ran).
+
+    Files put on dataverse have a database ID associated with them, while there
+    "path" in the dataverse dataset is treated as metadata to that file. The ID
+    is persistent, but not technically a content identifier as it is not created
+    from the content like hash. However, once files are published (by being part
+    of a published dataset version) those IDs can serve as a content identifier
+    for practical purposes, since they are not going to change anymore. There's
+    no "real" guarantee for that, but in reality changing it would require some
+    strange DB migration to be performed on the side of the respective dataverse
+    instance. Note, however, that a file can be pushed into a draft version and
+    replaced/removed before it was ever published. In that case the ID of an
+    annex key could be changed. Hence, to some extent the special remote needs
+    to be aware of whether an annex key and its ID was part of a released
+    version of the dataverse dataset in order to make use of those IDs.
+
+    Recording the IDs allows accessing older versions of a file even in export
+    mode, as well as faster accessing keys for download. The latter is because
+    the API requires the ID, and a path based approach would therefore require
+    looking up the ID first (adding a request). Therefore, the special remote
+    records the IDs of annex keys and tries to rely on them if possible.
+
+    There is one more trap to mention with dataverse and that is its limitations
+    to directory and file names.
+    See https://github.com/IQSS/dataverse/issues/8807#issuecomment-1164434278
+
+    Regular special remote
+    ----------------------
+
+    In principle the regular special remote simply maintains a flat list of
+    annex keys in the dataverse dataset, where the presented file names are the
+    anney keys. Therefore, it is feasible to simply rely on the remote path of a
+    key when checking for its presence. However, as laid out above, it is faster
+    to utilize knowledge about the database ID, so the idea is to use path
+    matching only as a fallback.
+
+    Export remote
+    -------------
+
+    In export mode the special remote can not conclude the annex key from a
+    remote path in general. In order to be able to access versions of a file
+    that are not part of the latest version (draft or not) of the dataverse
+    dataset, reliance on recorded database IDs is crucial.
+
+    datalad-annex special keys
+    --------------------------
+
+    The datalad-next extension provides a git-remote-helper to utilize cloning
+    from and pushing to any special remote via a "hidden", intermediate
+    repository. This approach comes with special annex keys representing a
+    packed git repository ("XDLRA--refs", "XDLRA--repo-export"). In opposition
+    to regular annex keys, those are not content specific. Their location in the
+    dataverse dataset will always be the same (meaning path matching is fine -
+    there's no notion of a previous version), and in some sense more
+    importantly: The git-remote-helper using them can not have any knowledge of
+    their database IDs, since they are recorded in the repository (in its
+    git-annex branch) that this helper is only about to retrieve. Hence, the
+    implementation of this special remote treats those keys as special cases
+    solely relying on path matching.
+
+    Implementation note
+    -------------------
+
+    The special remote at first only retrieves a record of what is in the latest
+    version (draft or not) of the dataverse dataset including an annotation of
+    content on whether it is released. This annotation is crucial, since it has
+    implications on what to record should changes be pushed to it.
+    For example:
+    It is not possible to actually remove content from a released version. That
+    means, if annex asks the special remote to remove content, it can only make
+    sure that the respective key is not part of the current draft anymore. Its
+    ID, however, remains on record. If the content was not released yet, it is
+    actually gone and the ID is taken off the record.
+
+    This record is retrieved lazily when first required, but only once (avoiding
+    an additional per-key request) and then updated locally when changes are
+    pushed. (Note, that we know that we only ever push into a draft version)
+    In case of checking the presence of a key that does not appear to be part of
+    the latest version, a request for such a record on all known dataverse
+    dataset versions is made. Again, this is lazy and only one request. This may
+    potentially be a relatively expensive request, but the introduced latency by
+    having smaller but possibly much more requests is likely a lot more
+    expensive.
+    """
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -174,7 +174,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         remote_dir = os.path.dirname(remote_file)
         # TODO: Pretty sure there's similar or identical restrictions to
         # filenames; Double-check and be clear here.
-        if re.search(pattern='[^a-z0-9_\-.\\/\ ]', string=remote_dir, flags=re.ASCII | re.IGNORECASE):
+        if re.search(pattern=r'[^a-z0-9_\-.\\/\ ]', string=remote_dir, flags=re.ASCII | re.IGNORECASE):
             self.annex.error(f"Invalid character in directory name of {remote_file}."
                              f"Valid characters are a-Z, 0-9, '_', '-', '.', '\\', '/' and ' ' (white space).")
 
@@ -249,7 +249,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
             auth=HTTPBasicAuth(self._token, ''))
         # http error handling
         status.raise_for_status()
-    
+
     def removeexport(self, key, remote_file):
         remote_file = str(mangle_directory_names(remote_file))
         return self.remove(key=remote_file)

--- a/datalad_dataverse/tests/test_create_sibling_dataverse.py
+++ b/datalad_dataverse/tests/test_create_sibling_dataverse.py
@@ -81,6 +81,15 @@ def test_workflow(path=None, clone_path=None, *, mode):
 )
 def _check_workflow(admin_api, ds, collection_alias, user, clone_path, mode):
 
+    with assert_raises(ValueError) as ve:
+        ds.create_sibling_dataverse(
+            url=DATAVERSE_TEST_URL,
+            collection='no-ffing-datalad-way-this-exists',
+            credential="dataverse",
+            **ckwa
+        )
+    assert 'among existing' in str(ve)
+
     ds_repo = ds.repo
     dspid = None
     try:
@@ -93,6 +102,7 @@ def _check_workflow(admin_api, ds, collection_alias, user, clone_path, mode):
                                               recursive=False,
                                               recursion_limit=None,
                                               metadata=None,
+                                              credential="dataverse",
                                               **ckwa)
         # make dataset removal work in `finally`
         # no being careful and get(), we really require it

--- a/datalad_dataverse/tests/test_create_sibling_dataverse.py
+++ b/datalad_dataverse/tests/test_create_sibling_dataverse.py
@@ -1,3 +1,9 @@
+import pytest
+from pyDataverse.exceptions import (
+    ApiAuthorizationError,
+    OperationFailedError,
+)
+
 from datalad.tests.utils_pytest import (
     assert_in,
     assert_raises,
@@ -11,12 +17,14 @@ from datalad.api import (
 from datalad.distribution.dataset import (
     Dataset,
 )
+from datalad.support.exceptions import CommandError
 from datalad_next.tests.utils import with_credential
 
 from datalad_dataverse.tests import (
     DATAVERSE_TEST_APITOKENS,
     DATAVERSE_TEST_COLLECTION_NAME,
     DATAVERSE_TEST_URL,
+    DEMO_DATAVERSE_URL,
 )
 from datalad_dataverse.tests.utils import (
     create_test_dataverse_collection,
@@ -37,32 +45,32 @@ def _prep_test(path):
         DATAVERSE_TEST_APITOKENS['testadmin'],
     )
     create_test_dataverse_collection(admin_api, DATAVERSE_TEST_COLLECTION_NAME)
+
+    # This may not work in all test setups due to lack of permissions or /root
+    # not being published or it being published already. Try though, since it's
+    # necessary to publish datasets in order to test against dataverse datasets
+    # with several versions.
+    try:
+        admin_api.publish_dataverse(DATAVERSE_TEST_COLLECTION_NAME)
+    except ApiAuthorizationError:
+        # Test setup doesn't allow for it
+        pass
+    except OperationFailedError as e:
+        print(str(e))
+
     return ds, admin_api
 
 
 @skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
+@pytest.mark.parametrize("mode", ["annex", "filetree"])
 @with_tempfile
 @with_tempfile
-def test_basic(path=None, clone_path=None):
+def test_workflow(path=None, clone_path=None, *, mode):
     ds, admin_api = _prep_test(path)
-    _check_basic_creation(
-        admin_api, ds, DATAVERSE_TEST_COLLECTION_NAME, 'testadmin', clone_path,
-        mode='annex',
-    )
-
-
-
-# Disable for now. Export mode is broken by
-# https://github.com/datalad/datalad-dataverse/issues/143
-@skip_if(True)
-@skip_if(cond='testadmin' not in DATAVERSE_TEST_APITOKENS)
-@with_tempfile
-@with_tempfile
-def test_basic_export(path=None, clone_path=None):
-    ds, admin_api = _prep_test(path)
-    _check_basic_creation(
-        admin_api, ds, DATAVERSE_TEST_COLLECTION_NAME, 'testadmin', clone_path,
-        mode='filetree',
+    _check_workflow(
+        admin_api, ds, DATAVERSE_TEST_COLLECTION_NAME, 'testadmin',
+        clone_path,
+        mode=mode,
     )
 
 
@@ -71,15 +79,9 @@ def test_basic_export(path=None, clone_path=None):
     secret=DATAVERSE_TEST_APITOKENS.get('testadmin'),
     realm=f'{DATAVERSE_TEST_URL.rstrip("/")}/dataverse',
 )
-def _check_basic_creation(
-        admin_api, ds, collection_alias, user, clone_path, mode):
-    with assert_raises(ValueError) as ve:
-        ds.create_sibling_dataverse(
-            url=DATAVERSE_TEST_URL,
-            collection='no-ffing-datalad-way-this-exists',
-            **ckwa
-        )
-    assert 'among existing' in str(ve)
+def _check_workflow(admin_api, ds, collection_alias, user, clone_path, mode):
+
+    ds_repo = ds.repo
     dspid = None
     try:
         results = ds.create_sibling_dataverse(url=DATAVERSE_TEST_URL,
@@ -114,14 +116,76 @@ def _check_basic_creation(
         # push should work now
         ds.push(to="git_remote", **ckwa)
         # drop content and retrieve again
-        ds.drop("somefile.txt", **ckwa)
+        # (reckless drop in export mode, since export is untrusted)
+        drop_param = dict(reckless='availability') if mode == 'filetree' else {}
+        ds.drop("somefile.txt", **drop_param, **ckwa)
         ds.get("somefile.txt", **ckwa)
+
+        # Move file:
+        (ds.pathobj / "subdir").mkdir()
+        (ds.pathobj / "somefile.txt").rename(ds.pathobj / "subdir" / "newname.md")
+        ds.save(message="Move a file")
+        ds.push(to="git_remote", **ckwa)
+
+        # Publish this version (if we can):
+        # May fail due to same reasons as the publication of the collection in
+        # `_prep_test`.
+        # Plus: Somehow this doesn't workout on demo.dataverse.org
+        #       Looks like we can't modify a published dataset there?
+        #       (In local docker setup that automatically creates a new draft
+        #       version)
+        # However, at least when possible (docker setup with published root
+        # collection), test some aspect of dealing with this.
+        if DATAVERSE_TEST_URL != DEMO_DATAVERSE_URL:
+            try:
+                response = admin_api.publish_dataset(dspid, release_type='major')
+            except Exception as e:
+                # nothing to do - we test what we can test, but print the reason
+                print(str(e))
+            published = response is not None and response.status_code == 200
+            if not published and response is not None:
+                # Publishing didn't succeed, but gave a json reponse not an
+                # exception - print in this case, too.
+                print(f"{response.json()}")
+        else:
+            published = False
+
+        # Add a file and push again (creating new draft version)
+        (ds.pathobj / "newfile.txt").write_text("Whatever new content")
+        ds.save(message="Add a file")
+        ds.push(to="git_remote", **ckwa)
+
+        # Remove the file and push again (into same draft version):
+        newfile_key = ds_repo.call_annex(['lookupkey', 'newfile.txt']).strip()
+        ds.drop("newfile.txt", **drop_param, **ckwa)
+        (ds.pathobj / "newfile.txt").unlink()
+        ds.save(message="Remove newfile.txt again")
+        ds.push(to="git_remote", **ckwa)
+
+        # The removal also is a content removal in export mode:
+        # Note: Getting the key, since in forced adjusted mode (windows), we
+        # can't simply checkout HEAD~1 and refer to the unfulfilled path.
+        # In filetree mode the `get` is supposed to fail, in annex mode the
+        # previous push doesn't affect the key file (we'd need to drop from the
+        # remote for that).
+        if mode == 'filetree':
+            assert_raises(CommandError,
+                          ds_repo.call_annex_records,
+                          ['get', '--key', newfile_key])
+        else:
+            ds_repo.call_annex_records(['get', '--key', newfile_key])
 
         # And we should be able to clone
         cloned_ds = clone(source=clone_url, path=clone_path,
                           result_xfm='datasets', **ckwa)
-        cloned_ds.repo.enable_remote('special_remote')
-        cloned_ds.get("somefile.txt", **ckwa)
+        cloned_repo = cloned_ds.repo
+        # we got the same thing
+        assert ds_repo.get_hexsha(ds_repo.get_corresponding_branch()) == \
+            cloned_repo.get_hexsha(cloned_repo.get_corresponding_branch())
+
+        cloned_repo.enable_remote('special_remote')
+        cloned_ds.get(str(cloned_ds.pathobj / "subdir" / "newname.md"), **ckwa)
+
     finally:
         if dspid:
             admin_api.destroy_dataset(dspid)

--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -120,10 +120,11 @@ def _check_datalad_annex(ds, dspid, clonepath):
         f'{DATAVERSE_TEST_URL}/dataset.xhtml?persistentId={dspid}&version=DRAFT',
     ):
         dsclone = clone(git_remote_url, clonepath)
+        cloned_repo = dsclone.repo
 
         # we got the same thing
-        assert repo.get_hexsha(ds.repo.get_corresponding_branch()) == \
-            dsclone.repo.get_hexsha(ds.repo.get_corresponding_branch())
+        assert repo.get_hexsha(repo.get_corresponding_branch()) == \
+            cloned_repo.get_hexsha(cloned_repo.get_corresponding_branch())
 
         # cleanup for the next iteration
         rmtree(clonepath)

--- a/datalad_dataverse/utils.py
+++ b/datalad_dataverse/utils.py
@@ -93,7 +93,7 @@ def get_api(url, credman, credential_name=None):
             # at the very end, and can use it for discovery next time
             realm=credential_realm,
         )
-    if 'secret' not in cred:
+    if cred is None or 'secret' not in cred:
         raise LookupError('No suitable credential found')
 
     # connect to dataverse instance

--- a/tools/ci/setup_docker_dataverse.sh
+++ b/tools/ci/setup_docker_dataverse.sh
@@ -88,7 +88,7 @@ else
   echo "Failed to receive token for 'testadmin'. Got: ${token_admin}"
   exit 1
 fi
-# Check validity of received token for 'uma'
+# Check validity of received token for 'user1'
 if [ -n "${token_userone}" ] && [ "${token_userone}" != "null" ]; then
   echo "Token for 'user1' received: ${token_userone}"
   useroneResp=$(curl -H "X-Dataverse-key:${token_userone}" "http://localhost:8080/api/users/:me")
@@ -103,3 +103,6 @@ else
   echo "Failed to receive token for 'user1'. Got: ${token_userone}"
   exit 1
 fi
+
+# Publish root dataverse to allow publishing things underneath:
+curl -H "X-Dataverse-key:${token_admin}" "http://localhost:8080/api/dataverses/science/actions/:publish"


### PR DESCRIPTION
This replaces PR #147 since the PR needs to come from within the github repository in order for CI to have access to secrets.

A description of how the special remote now works is included in the docstring of the special remote class (see https://github.com/datalad/datalad-dataverse/pull/154/commits/37ec8f20157679ba07b067e29f4b5bb712c9d73d)

Closes #143

- Arguably there is more to the issues #143, #83, but with respect to pushing the repo itself via `datalad-annex` remote helper this is not relevant and I therefore I think this is closing #143 and partially addresses #83 (see comment there as to how to actually close it).

- Second, addressing #146, the reimplementation stores dataverse's database ID for uploaded files in the git-annex branch (utilizing annex' `SETSTATE`/`GETSTATE` special remote feature) and therefore does not primarily rely on some path matching anymore. However, limited path matching as a fallback is required or desirable in two cases from my POV:
  1. Required: The special keys of the `datalad-annex` git remote helper need to be matched by path, since the throwaway repository using them can't have access to a git-annex branch delivering the ID (especially when cloning from datalad-annex URL)
  2. In regular non-export mode, we store keys under their name. Matching them as a fallback has little potential to go wrong (someone would need to upload mismatching content under an annex keys' filename), while it would provide some means to recover from a messed up situation. Say, someone uploaded via `annex-copy` w/o pushing the annex branch. Or the annex branch was messed up somehow. With filename matching as fallback there would still be a way to recover the data w/o reuploading. So - for annex mode I think it's worth it as fallback.

- This implementation should be faster as it saves a bunch of requests. Examples:
  1. `checkpresent(export)` used to send the same request every time. This is now cached and updated locally when we push changes (`self.files_*`) from within the same process.
  2. implemented `renameexport` to only change the metadata of an uploaded file when it was moved. W/O this method being implemented, annex would do a REMOVEEXPORT + TRANSFEREXPORT_STORE which is (a lot) more expensive.

- Apart from "invalid" file/directory names, export now works full cycle including repeated pushes and is tested accordingly. Part of the problem was the former path matching which was in fact a filename matching instead.

- Uploading a file with the same path (already present in the latest version of the dataverse dataset) would lead to dataverse renaming the file. This is now addressed by replacing the file instead under those conditions.

- Work on this patch led to discovering an issue with datalad-next's patch to `push` to allow for pushing to an export remote. Hence, https://github.com/datalad/datalad-next/pull/93 is required for this PR (and its test) to work!


Please also consider this response to a previous round of review, if this description and remote's docstring seem insufficient https://github.com/datalad/datalad-dataverse/pull/147#issuecomment-1214458693


There are things that remain to be done. This is:
- Finish work on #83 by extending the "mangling" as necessary
- Figure out how to deal with https://github.com/datalad/datalad-dataverse/issues/146#issuecomment-1214409351
- #155
- #148

However, I consider this to be the better, faster and more complete basis to do so, than what is currently in `main`.
