### PR TITLE
Bluntly rip out DATALAD_ANNEX_SPECIAL_KEYS handling

### DIFF
--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -293,7 +293,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # In export mode, we need to fix remote paths:
         remote_file = mangle_directory_names(remote_file)
 
-        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file)
+        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file, latest_only=True)
         if file_id is None:
             raise RemoteError(f"Key {key} unavailable")
 
@@ -323,7 +323,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         filename = mangle_directory_names(filename)
         new_filename = mangle_directory_names(new_filename)
 
-        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(filename)
+        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(filename, latest_only=True)
         if file_id is None:
             raise RemoteError(f"{key} not available for renaming")
 
@@ -536,7 +536,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
     def _get_fileid_from_key(self,
                              key: str,
-                             latest_only: bool = True) -> int | None:
+                             *,
+                             latest_only: bool) -> int | None:
         """Get the id of a dataverse file, that matches a given annex key
         dataverse dataset.
 
@@ -568,7 +569,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
     def _get_fileid_from_exportpath(self,
                                     path: Path,
-                                    latest_only: bool = True) -> int | None:
+                                    *,
+                                    latest_only: bool) -> int | None:
         """Get the id of a dataverse file, that matches a given `Path` in the
         dataverse dataset.
 
@@ -598,7 +600,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # upload the file, since otherwise dataverse would rename the file on
         # its end. However, this only concerns the latest version of the dataset
         # (which is what we are pushing into)!
-        replace_id = self._get_fileid_from_exportpath(remote_file)
+        replace_id = self._get_fileid_from_exportpath(remote_file, latest_only=True)
         if replace_id is not None:
             self.message(f"Replacing {remote_file} ...", type='debug')
             response = self._api.replace_datafile(
@@ -667,7 +669,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
     def _remove_file(self, key, remote_file):
         """helper for both remove methods"""
-        rm_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file)
+        rm_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file, latest_only=True)
 
         if rm_id is None:
             # We didn't find anything to remove. That should be fine and

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -522,7 +522,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         else:
             return int(stored_id)
 
-    def set_stored_id(self, key, id):
+    def _set_annex_fileid_record(self, key, id):
         """Store a dataverse database id for a given key
 
         Parameters
@@ -617,13 +617,13 @@ class DataverseRemote(ExportRemote, SpecialRemote):
             # file list (`self.files_old`).
             if not (self.files_latest[replace_id].is_released or
                     replace_id in self.files_old.keys()):
-                self.set_stored_id(key, "")
+                self._set_annex_fileid_record(key, "")
 
         uploaded_file = response.json()['data']['files'][0]
         # update cache:
         self.add_to_filelist(uploaded_file)
         # remember dataverse's database id for this key
-        self.set_stored_id(key, uploaded_file['dataFile']['id'])
+        self._set_annex_fileid_record(key, uploaded_file['dataFile']['id'])
 
     def _download_file(self, file_id, local_file):
         """helper for both transfer-retrieve methods"""
@@ -660,7 +660,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         if not (self.files_latest[rm_id].is_released or
                 rm_id in self.files_old.keys()):
             self.message(f"Unset stored id for {key}", type='debug')
-            self.set_stored_id(key, "")
+            self._set_annex_fileid_record(key, "")
         else:
             # Despite not actually deleting from the dataverse database, we
             # currently loose access to the old key (in export mode, that is),

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -244,7 +244,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         else:
             # Like in `self.checkpresent`, we fall back to path matching.
             # Delayed checking for availability from old versions is included.
-            file_id = self._get_fileid_from_exportpath(Path(key), latest_only=False)
+            file_id = self._get_fileid_from_key(key, latest_only=False)
             if file_id is None:
                 raise RemoteError(f"Key {key} unavailable")
 
@@ -533,6 +533,38 @@ class DataverseRemote(ExportRemote, SpecialRemote):
             dataverse database id for `key`. Empty string to unset.
         """
         self.annex.setstate(key, str(id))
+
+    def _get_fileid_from_key(self,
+                             key: str,
+                             latest_only: bool = True) -> int | None:
+        """Get the id of a dataverse file, that matches a given annex key
+        dataverse dataset.
+
+        This method assumes that keys are deposited under paths that are
+        identical to the key name.
+
+        Parameters
+        ----------
+        key:
+            Annex key to perform the lookup for
+        latest_only: bool
+            Whether to only consider the latest version on dataverse. If
+            `False`, matching against older versions will only be performed
+            when there was no match in the latest version (implies that an
+            additional request may be performed)
+
+        Returns
+        -------
+        int or None
+        """
+        # for now this also just performs a look-up by path
+        # but if other metadata-based lookups become possible
+        # this implementation could change
+        # https://github.com/datalad/datalad-dataverse/issues/188
+        return self._get_fileid_from_exportpath(
+            Path(key),
+            latest_only=latest_only,
+        )
 
     def _get_fileid_from_exportpath(self,
                                     path: Path,

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -642,17 +642,14 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
     def _remove_file(self, key, remote_file):
         """helper for both remove methods"""
-        stored_id = self.get_stored_id(key)
-        rm_id = None
-        if stored_id is not None:
-            rm_id = stored_id
-            if rm_id not in self.files_latest.keys():
-                # We can't remove from older (hence published) versions.
-                return
+        rm_id = self.get_stored_id(key) or self.get_id_by_path(remote_file)
 
         if rm_id is None:
             # We didn't find anything to remove. That should be fine and
             # considered a successful removal by git-annex.
+            return
+        if rm_id not in self.files_latest.keys():
+            # We can't remove from older (hence published) versions.
             return
 
         status = delete(

--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -293,7 +293,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # In export mode, we need to fix remote paths:
         remote_file = mangle_directory_names(remote_file)
 
-        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file, latest_only=True)
+        file_id = self._get_annex_fileid_record(key) \
+            or self._get_fileid_from_exportpath(remote_file, latest_only=True)
         if file_id is None:
             raise RemoteError(f"Key {key} unavailable")
 
@@ -323,7 +324,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         filename = mangle_directory_names(filename)
         new_filename = mangle_directory_names(new_filename)
 
-        file_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(filename, latest_only=True)
+        file_id = self._get_annex_fileid_record(key) \
+            or self._get_fileid_from_exportpath(filename, latest_only=True)
         if file_id is None:
             raise RemoteError(f"{key} not available for renaming")
 
@@ -600,7 +602,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # upload the file, since otherwise dataverse would rename the file on
         # its end. However, this only concerns the latest version of the dataset
         # (which is what we are pushing into)!
-        replace_id = self._get_fileid_from_exportpath(remote_file, latest_only=True)
+        replace_id = self._get_fileid_from_exportpath(
+            remote_file, latest_only=True)
         if replace_id is not None:
             self.message(f"Replacing {remote_file} ...", type='debug')
             response = self._api.replace_datafile(
@@ -669,7 +672,8 @@ class DataverseRemote(ExportRemote, SpecialRemote):
 
     def _remove_file(self, key, remote_file):
         """helper for both remove methods"""
-        rm_id = self._get_annex_fileid_record(key) or self._get_fileid_from_exportpath(remote_file, latest_only=True)
+        rm_id = self._get_annex_fileid_record(key) \
+            or self._get_fileid_from_exportpath(remote_file, latest_only=True)
 
         if rm_id is None:
             # We didn't find anything to remove. That should be fine and


### PR DESCRIPTION
As speculated in #180 there should be no need for any special casing. Hence I tried to just rip all respective conditionals out.

Locally that makes no difference re the associated `datalad_annex` test.

Possibly this means that special casing only had an impact on the operations in export mode (which seems to be untested).

Closes #180
Closes #190