### PR TITLE
Replace non-sensical call

### DIFF
--- a/datalad_dataverse/remote.py
+++ b/datalad_dataverse/remote.py
@@ -645,7 +645,7 @@ class DataverseRemote(ExportRemote, SpecialRemote):
         # If we replaced, `replaced_id` is not part of the latest version
         # anymore.
         if replace_id is not None:
-            self.remove_from_filelist(re)
+            self.remove_from_filelist(replace_id)
             # In case of replace we need to figure whether the replaced
             # ID was part of a DRAFT version only. In that case it's gone and
             # we'd need to remove the ID record. Otherwise, it's still retrieval


### PR DESCRIPTION
`self.remove_from_filelist(re)`, where `re` is the Python regex module.

It is now passing `replace_id`, which is checked for `not None` directly before. However, this is a blind fix. Clearly this part of the code is not tested enough to be able to tell whether this is actually a fix.

Closes #195