### PR TITLE
`OnlineDataverseDataset.rename_file()`

### DIFF
--- a/datalad_dataverse/dataset.py
+++ b/datalad_dataverse/dataset.py
@@ -173,7 +173,7 @@ class OnlineDataverseDataset:
         Raises
         ------
         RuntimeError
-          Whenever the operation cannot or did not success. This could be,
+          Whenever the operation cannot or did not succeed. This could be
           because of a missing dependency, or because the file in question
           cannot be renamed (included in an earlier version).
         """


### PR DESCRIPTION
This allows for removing any direct dependency of the special remote implementations from `pyDataverse` (ping #200).

Closes #219