### PR TITLE
Skip null quoting of names

### DIFF
--- a/datalad_dataverse/tests/test_utils.py
+++ b/datalad_dataverse/tests/test_utils.py
@@ -73,3 +73,9 @@ def test_dir_quoting_leading_dot():
         q = _dataverse_dirname_quote(p)
         assert q[0] != "."
         assert p == _dataverse_unquote(q)
+
+
+def test_null_quoting_skip():
+    s = "a---b"
+    assert s == _dataverse_dirname_quote(s)
+    assert s == _dataverse_filename_quote(s)

--- a/datalad_dataverse/utils.py
+++ b/datalad_dataverse/utils.py
@@ -365,6 +365,10 @@ def _dataverse_quote(name: str,
         )
 
     assert esc in safe
+
+    if set(name).issubset(safe):
+        return name
+
     return "".join([
         f"{esc}{ord(c):02X}" if c not in safe or c == esc else c
         for c in name


### PR DESCRIPTION
This PR changes the encoding to skip encoding if a string only contains characters from the safe set (including the escape character itself).

That should fix errors with encoded annex-object names, e.g. [here](https://ci.appveyor.com/project/mih/datalad-dataverse/builds/46485102):
```
FAILED ../tests/test_remote.py::test_remote[no] - AssertionError: assert 'MD5E-2Ds7-2D...0284c8555.txt' == 'MD5E-s7--9a0...0284c8555.txt'
  - MD5E-s7--9a0364b9e99bb480dd25e1f0284c8555.txt
  + MD5E-2Ds7-2D-2D9a0364b9e99bb480dd25e1f0284c8555.txt
```

The error started appearing, when the standard escape character was changed from ``_`` to ``-`` in order to have a "nicer" looking encoding of names like ``.datalad`` in the dataverse dataset-display