### PR TITLE
Encode all non-safe file name characters including unicode-characters

### DIFF
--- a/datalad_dataverse/tests/test_utils.py
+++ b/datalad_dataverse/tests/test_utils.py
@@ -1,3 +1,5 @@
+import unicodedata
+import unicodedata
 from itertools import product
 from pathlib import PurePosixPath
 
@@ -11,6 +13,9 @@ from ..utils import (
     mangle_path,
     unmangle_path
 )
+
+
+dog_cat = unicodedata.lookup('dog face') + unicodedata.lookup('cat face')
 
 
 _test_paths = [
@@ -33,6 +38,9 @@ _test_paths = [
     "_.dir/x",
     "__dir/x",
     "%%;;,_,?-&=",
+    "?;#:eee=2.txt",
+    "überfüllt",
+    dog_cat
 ]
 
 
@@ -73,3 +81,8 @@ def test_dir_quoting_leading_dot():
         q = _dataverse_dirname_quote(p)
         assert q[0] != "."
         assert p == _dataverse_unquote(q)
+
+
+def test_unicode_quoting_leading_dot():
+    for p in ["\u20ac", "ööl-ins-feuäär", dog_cat]:
+        assert p == _dataverse_unquote(_dataverse_dirname_quote(p))


### PR DESCRIPTION
*Not sure this is helpful, but it would take care of Unicode file-name handling, if I am not mistaken. WDYT?*

This PR enables path mangling to encode all non-safe characters including Unicode-characters. This is a simple hex-number based encoding that servers two purposes:

- convert a given file name into a legal "dataverse" file name
- ensure that different given file names are mapped onto different dataverse files, i.e. no name collisions

Encoding become a little more bulky because codes have an escape character at the beginning and the end of the encoding.
