### PR TITLE
Consistent use of PurePosixPath for the dataverse remote path

### DIFF
--- a/datalad_dataverse/baseremote.py
+++ b/datalad_dataverse/baseremote.py
@@ -176,7 +176,6 @@ class DataverseRemote(SpecialRemote):
         replace_id = self._get_fileid_from_key(key, latest_only=True)
 
         self._upload_file(
-            # TODO must be PurePosixPath
             remote_path=self._get_remotepath_for_key(key),
             key=key,
             local_file=local_file,
@@ -328,7 +327,7 @@ class DataverseRemote(SpecialRemote):
 
     def _get_fileid_from_remotepath(
             self,
-            path: Path,
+            path: PurePosixPath,
             *,
             latest_only: bool) -> int | None:
         return self._dvds.get_fileid_from_path(path, latest_only=latest_only)

--- a/datalad_dataverse/baseremote.py
+++ b/datalad_dataverse/baseremote.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import (
     Path,
+    PurePath,
     PurePosixPath,
 )
 
@@ -288,7 +289,8 @@ class DataverseRemote(SpecialRemote):
         PurePosixPath
           annex/<dirhash-lower>/<key>
         """
-        dirhash = self.annex.dirhash_lower(key)
+        # dirhash is reported in platform conventions by git-annex
+        dirhash = PurePath(self.annex.dirhash_lower(key))
         return PurePosixPath(
             'annex',
             dirhash,

--- a/datalad_dataverse/tests/test_dataset.py
+++ b/datalad_dataverse/tests/test_dataset.py
@@ -4,10 +4,7 @@ These tests (should) somewhat close mirror the ones fpr pydataverse.
 At least as long as we are using that API layer.
 """
 
-from pathlib import (
-    Path,
-    PurePosixPath,
-)
+from pathlib import PurePosixPath
 import json
 
 from datalad_next.tests.utils import md5sum
@@ -42,7 +39,7 @@ def test_file_handling(
 
     check_rename_file(odd, fileid)
 
-    check_remove(odd, fileid, Path(fpath.name))
+    check_remove(odd, fileid, PurePosixPath(fpath.name))
 
     check_duplicate_file_deposition(odd, tmp_path)
 
@@ -96,7 +93,7 @@ def check_duplicate_file_deposition(odd, tmp_path):
 
 def check_upload(odd, fcontent, fpath, src_md5):
     # the simplest possible upload, just a source file name
-    remote_path = Path(fpath.name)
+    remote_path = PurePosixPath(fpath.name)
     file_id = odd.upload_file(fpath, remote_path)
     # internal consistency
     assert odd.has_fileid(file_id)

--- a/datalad_dataverse/tests/test_utils.py
+++ b/datalad_dataverse/tests/test_utils.py
@@ -1,5 +1,5 @@
 from itertools import product
-from pathlib import Path
+from pathlib import PurePosixPath
 
 import pytest
 
@@ -51,12 +51,12 @@ def test_format_doi():
 
 def test_path_mangling_identity():
     for p in _test_paths + ['?;#:eee=2.txt']:
-        assert Path(p) == unmangle_path(mangle_path(p))
+        assert PurePosixPath(p) == unmangle_path(mangle_path(p))
 
 
 def test_path_mangling_sub_dirs():
     for p, q, r in product(_test_paths, _test_paths, _test_paths):
-        path = Path(p) / q / r
+        path = PurePosixPath(p) / q / r
         mangled_path = mangle_path(path)
         for part in mangled_path.parts[:-1]:
             assert part[0] != "."

--- a/datalad_dataverse/utils.py
+++ b/datalad_dataverse/utils.py
@@ -227,9 +227,9 @@ def mangle_path(path: str | PurePosixPath) -> PurePosixPath:
         # hence the code block below must be protected against this case.
         dataverse_path = dpath
     else:
-        dataverse_path = PurePosixPath(_dataverse_dirname_quote(dpath.parts[0]))
-        for pt in dpath.parts[1:]:
-            dataverse_path /= _dataverse_dirname_quote(pt)
+        dataverse_path = PurePosixPath(
+            *[_dataverse_dirname_quote(pt) for pt in dpath.parts]
+        )
 
     # re-append file if necessary
     if filename:
@@ -261,9 +261,9 @@ def unmangle_path(dataverse_path: str | PurePosixPath) -> PurePosixPath:
         # hence the code block below must be protected against this case.
         result_path = dataverse_path
     else:
-        result_path = PurePosixPath(_dataverse_unquote(dataverse_path.parts[0]))
-        for pt in dataverse_path.parts[1:]:
-            result_path /= _dataverse_unquote(pt)
+        result_path = PurePosixPath(
+            *[_dataverse_unquote(pt) for pt in dataverse_path.parts]
+        )
     return result_path
 
 


### PR DESCRIPTION
Closes #220
Closes #259 

Last TODOs

```
=========================== short test summary info ===========================
798FAILED ..\tests\test_utils.py::test_path_mangling_identity - AssertionError: assert WindowsPath('.x') == PurePosixPath('.x')
799 +  where WindowsPath('.x') = Path('.x')
800 +  and   PurePosixPath('.x') = unmangle_path(PurePosixPath('_.x'))
801 +    where PurePosixPath('_.x') = mangle_path('.x')
802FAILED ..\tests\test_utils.py::test_path_mangling_sub_dirs - AssertionError: assert PurePosixPath('.x/.x/.x') == WindowsPath('.x/.x/.x')
803 +  where PurePosixPath('.x/.x/.x') = unmangle_path(PurePosixPath('_.x/_.x/_.x'))
804============ 2 failed, 14 passed, 4 warnings in 845.08s (0:14:05) =============
805
```