### PR TITLE
Support scoping within Dataverse datasets

### DIFF
--- a/datalad_dataverse/__init__.py
+++ b/datalad_dataverse/__init__.py
@@ -32,7 +32,7 @@ register_config(
     description="Convenience conversion of Dataverse dataset landing page "
     "URLs to git-cloneable 'datalad-annex::'-type URLs. It enables cloning "
     "from dataset webpage directly, and implies a remote sibling in 'annex' "
-    "mode (i.e., with keys, not exports) "
+    "mode (i.e., with keys, not exports) and no alternative root path being used"
     "See https://docs.datalad.org/design/url_substitution.html for details",
     dialog='question',
     scope='global',

--- a/datalad_dataverse/baseremote.py
+++ b/datalad_dataverse/baseremote.py
@@ -100,11 +100,11 @@ class DataverseRemote(SpecialRemote):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.configs['url'] = 'The Dataverse URL for the remote'
-        self.configs['doi'] = 'DOI to the dataset'
+        self.configs['url'] = 'URL of the Dataverse site'
+        self.configs['doi'] = \
+            'DOI-style persistent identifier of the Dataverse dataset'
         self.configs['credential'] = \
-            'Identifier used to retrieve an API token from a local ' \
-            'credential store'
+            'name of a DataLad credential with a Dataverse API token to use'
         # dataverse dataset interface
         self._dvds = None
 

--- a/datalad_dataverse/baseremote.py
+++ b/datalad_dataverse/baseremote.py
@@ -103,6 +103,8 @@ class DataverseRemote(SpecialRemote):
         self.configs['url'] = 'URL of the Dataverse site'
         self.configs['doi'] = \
             'DOI-style persistent identifier of the Dataverse dataset'
+        self.configs['rootpath'] = \
+            'optional alternative root path to use in the Dataverse dataset'
         self.configs['credential'] = \
             'name of a DataLad credential with a Dataverse API token to use'
         # dataverse dataset interface
@@ -119,6 +121,7 @@ class DataverseRemote(SpecialRemote):
         doi = self.annex.getconfig('doi')
         if not doi:
             raise ValueError('doi must be specified')
+        dv_root_path = self.annex.getconfig('rootpath')
         # standardize formatting to minimize complexity downstream
         doi = format_doi(doi)
         # we need an access token, use the repo's configmanager to query for one
@@ -145,10 +148,9 @@ class DataverseRemote(SpecialRemote):
             apitoken,
         )
         # TODO this can raise, capture and raise proper error
-        self._dvds = OnlineDataverseDataset(api, doi)
+        self._dvds = OnlineDataverseDataset(api, doi, root_path=dv_root_path)
         # save the credential, now that it has successfully been used
         credman.set(credential_name, _lastused=True, **cred)
-
 
     def initremote(self):
         """


### PR DESCRIPTION
As a replacement of dedicated support for recursive deposition,
`add_sibling_dataverse` now supports a `root_path` option (`None` by
default) that enables users to identify a root `directoryLabel` for a
particular DataLad dataset inside a Dataverse dataset. This option is
mirrored as `rootpath=` for the special remote. `add_sibling_dataverse`
merely passes it through.

It is implemented as a front-end to `mangle_path()` within
`OnlineDataverseDataset` and limits all path-based operations to be
within a given root.

This now makes it possible to represent any number of DataLad datasets
in a single Dataverse dataset. This approachs matches the requirement to
create Dataverse datasets manually, and does not constrain automation of
data deposition with large DataLad dataset hierarchies.  Providing
a `root_path` rather than `--recursive` enables users to choose their own
organization of subdatasets within the Dataverse dataset, rather than
imposing a select few. Recursive operation could be done by users via
`for_each_dataset`.

A test is included that documents the ability to deposit nested dataset
hierarchies and re-clone them recursively.

Closes #271
