### PR TITLE
Replace `response.ok` with `response.status_code < 400`

### DIFF
--- a/datalad_dataverse/dataset.py
+++ b/datalad_dataverse/dataset.py
@@ -94,7 +94,7 @@ class OnlineDataverseDataset:
         # check if project with specified doi exists
         # TODO ask for ':latest' and cache?
         dv_ds = api.get_dataset(identifier=dsid)
-        if not dv_ds.ok:
+        if not dv_ds.status_code < 400:
             raise RuntimeError("Cannot find dataset")
 
     def get_fileid_from_path(


### PR DESCRIPTION
The .ok is part of the [requests API](https://requests.readthedocs.io/en/latest/api/#requests.Response.ok), but not part of the httpx API. An equivalent check, according to the requests docs, is to use response.status_code < 400 (In fact, requests' implementation is a try/except around raise_for_status, but this should be the same, although we could use the same pattern instead.)

Note that response.status_code < 400 should work with both, requests and httpx, and thus remain backwards compatible.

Closes #308.