### PR TITLE
Replace iter_content with iter_bytes

### DIFF
--- a/datalad_dataverse/dataset.py
+++ b/datalad_dataverse/dataset.py
@@ -177,7 +177,7 @@ class OnlineDataverseDataset:
         with path.open("wb") as f:
             # `chunk_size=None` means
             # "read data in whatever size the chunks are received"
-            for chunk in response.iter_content(chunk_size=None):
+            for chunk in response.iter_bytes(chunk_size=None):
                 f.write(chunk)
 
     def remove_file(self, fid: int):

--- a/datalad_dataverse/tests/test_pydataverse.py
+++ b/datalad_dataverse/tests/test_pydataverse.py
@@ -61,7 +61,7 @@ def check_download(api, fileid, dsid, fpath, src_md5):
     with fpath.open("wb") as f:
         # use a stupdly small chunksize to actual get chunking on
         # our tiny test file
-        for chunk in response.iter_content(chunk_size=1):
+        for chunk in response.iter_bytes(chunk_size=1):
             f.write(chunk)
 
     # confirm identity


### PR DESCRIPTION
Closes #312.

An alternative to keep the code backwards compatible with older pydataverse versions would be, for example, to first get the iterator and then use it:

```python
try:
    it = response.iter_content
except AttributeError:
    it = response.iter_bytes
for chunk in it(chunk_size=None):
    f.write(chunk)
```

There might be similar options as well, or maybe it would make sense to first try iter_bytes and fallback to iter_content.