### PR TITLE
Allow check_upload assets to use docker

### DIFF
--- a/datalad_dataverse/tests/test_pydataverse.py
+++ b/datalad_dataverse/tests/test_pydataverse.py
@@ -2,6 +2,7 @@
 
 import datetime
 import json
+import os
 from requests import delete
 from requests.auth import HTTPBasicAuth
 
@@ -140,7 +141,12 @@ def check_upload(api, dsid, fcontent, fpath, src_md5):
     # TODO: seemingly discontinued between Dataverse 5.13 and 6.0?
     #assert df['pidURL'] == ''
     assert df['rootDataFileId'] == -1
-    assert df['storageIdentifier'].startswith('s3://demo-dataverse')
+
+    dv_url = os.getenv('DATAVERSE_TEST_BASEURL')
+    if 'localhost' in dv_url or '127.0.0.1' in dv_url:
+        assert df['storageIdentifier'].startswith('local://')
+    else:
+        assert df['storageIdentifier'].startswith('s3://demo-dataverse')
 
     # report the file ID for external use
     return df['id']

--- a/datalad_dataverse/tests/test_pydataverse.py
+++ b/datalad_dataverse/tests/test_pydataverse.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import os
 from requests import delete
 from requests.auth import HTTPBasicAuth
 
@@ -26,6 +25,7 @@ def test_file_handling(
         dataverse_admin_api,
         dataverse_dataaccess_api,
         dataverse_dataset,
+        dataverse_instance_url,
 ):
     # the starting point of `dataverse_dataset` is a freshly
     # created, non-published dataset in draft mode, with no prior
@@ -42,7 +42,7 @@ def test_file_handling(
 
     fileid = check_upload(
         dataverse_admin_api,
-        dataverse_dataset, fcontent, fpath, src_md5)
+        dataverse_dataset, fcontent, fpath, src_md5, dataverse_instance_url)
 
     check_download(
         dataverse_dataaccess_api, fileid,
@@ -105,7 +105,7 @@ def check_duplicate_file_deposition(api, dsid, tmp_path):
                for f in identicals)
 
 
-def check_upload(api, dsid, fcontent, fpath, src_md5):
+def check_upload(api, dsid, fcontent, fpath, src_md5, dv_url):
     # the simplest possible upload, just a source file name
     response = api.upload_datafile(
         identifier=dsid,
@@ -142,7 +142,6 @@ def check_upload(api, dsid, fcontent, fpath, src_md5):
     #assert df['pidURL'] == ''
     assert df['rootDataFileId'] == -1
 
-    dv_url = os.getenv('DATAVERSE_TEST_BASEURL')
     if 'localhost' in dv_url or '127.0.0.1' in dv_url:
         assert df['storageIdentifier'].startswith('local://')
     else:


### PR DESCRIPTION
The docker compose setup as used in pyDataverse uses a different storage backend than demo.dataverse.org, so the storageIdentifier reports a non-s3:// address.

This commit detects the two most common ways of specifying localhost (leaving out 127.1 and the like) to allow for `local://` storageIdentifiers.

Relates to #320.