### PR TITLE
test: Adjust testremote for expected failure amount

### DIFF
--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -3,6 +3,7 @@ from urllib.parse import quote as urlquote
 
 from datalad.api import clone
 
+from datalad_next.exceptions import CommandError
 from datalad_next.utils import (
     on_windows,
     rmtree,
@@ -78,9 +79,13 @@ def test_remote(dataverse_admin_credential_setup,
             'drop', '--from', 'mydv', 'somefile.txt',
         ])
     # run git-annex own testsuite
-    ds.repo.call_annex([
-        'testremote', '--fast', 'mydv',
-    ])
+    # since Dataverse version 5.0, "storeKey when already present" will
+    # fail, as Dataverse forbids replacing files with identical names and
+    # checksums: https://guides.dataverse.org/en/latest/user/dataset-management.html#duplicate-files
+    with pytest.raises(CommandError, match='4 out of 125 tests failed'):
+        ds.repo.call_annex([
+            'testremote', '--fast', 'mydv',
+        ])
 
 
 def test_datalad_annex(dataverse_admin_credential_setup,


### PR DESCRIPTION
Since Dataverse version 5.0, "storeKey when already present" of git-annex testremote will fail, as Dataverse forbade replacing files with identical names and checksums:
https://guides.dataverse.org/en/latest/user/dataset-management.html#duplicate-files Because we can't exclude any test from the test suite, but wouldn't want to disable the entire test suite, this change - rather ugly-ly - expects the check to fail, and tests for the right amount of failures in the test suite.

Note that it should hopefully be okay to only adjust the tests for this altered behavior of the remote - a checkpresent prior to transfer operations should AFAIK prevent upload/replace attempts of identical files.


see #320 for explorations.