### PR TITLE
TMP: Check for remaining test failures

### DIFF
--- a/datalad_dataverse/tests/test_add_sibling_dataverse.py
+++ b/datalad_dataverse/tests/test_add_sibling_dataverse.py
@@ -25,7 +25,7 @@ def test_asdv_invalid_calls(
             credential="dataverse",
             **ckwa
         )
-    assert 'doi:no-ffing-datalad-way-this-exists not found' in str(ve.value)
+    assert 'Cannot find dataset' in str(ve.value)
 
 
 @pytest.mark.parametrize("mode", ["annex", "filetree"])

--- a/datalad_dataverse/tests/test_remote.py
+++ b/datalad_dataverse/tests/test_remote.py
@@ -3,6 +3,7 @@ from urllib.parse import quote as urlquote
 
 from datalad.api import clone
 
+from datalad_next.exceptions import CommandError
 from datalad_next.utils import (
     on_windows,
     rmtree,
@@ -78,9 +79,13 @@ def test_remote(dataverse_admin_credential_setup,
             'drop', '--from', 'mydv', 'somefile.txt',
         ])
     # run git-annex own testsuite
-    ds.repo.call_annex([
-        'testremote', '--fast', 'mydv',
-    ])
+    # since Dataverse version 5.0, "storeKey when already present" will
+    # fail, as Dataverse forbids replacing files with identical names and
+    # checksums: https://guides.dataverse.org/en/latest/user/dataset-management.html#duplicate-files
+    with pytest.raises(CommandError, match='4 out of 125 tests failed'):
+        ds.repo.call_annex([
+            'testremote', '--fast', 'mydv',
+        ])
 
 
 def test_datalad_annex(dataverse_admin_credential_setup,

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ python_requires = >= 3.7
 install_requires =
     datalad_next >= 1.0.0b2
     datalad >= 0.18.0
-    pydataverse
+    pydataverse @ git+https://github.com/gdcc/pydataverse@a2e48a2#egg=pydataverse
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
this temporarily merged the two open test-modifying PR branches, and depends on bleeding edge dataverse. Hopefully, this resolves remaining test failures - otherwise, we know what else to fix before a release.