### PR TITLE
Add a crude version check for parameter compatibility with JülichData

### DIFF
--- a/datalad_dataverse/dataset.py
+++ b/datalad_dataverse/dataset.py
@@ -10,6 +10,7 @@ from pathlib import (
 )
 import re
 
+from looseversion import LooseVersion
 from pyDataverse.api import ApiAuthorizationError
 from pyDataverse.models import Datafile
 from requests import (
@@ -171,7 +172,14 @@ class OnlineDataverseDataset:
         # https://github.com/gdcc/pyDataverse/issues/49
         # the code below is nevertheless readied for such a
         # scenario
-        response = self.data_access_api.get_datafile(fid, is_pid=False, data_format="original")
+        # for JülichData compatibility while still running on 4.20, a
+        # version-dependent parameter adjustment is necessary
+        version = self._api.get_info_version().json()['data']['version']
+        if LooseVersion(version) < LooseVersion("6.0"):
+            response = self.data_access_api.get_datafile(fid, is_pid=False)
+        else:
+            # see https://github.com/datalad/datalad-dataverse/issues/307
+            response = self.data_access_api.get_datafile(fid, is_pid=False, data_format="original")
         # http error handling
         response.raise_for_status()
         with path.open("wb") as f:

--- a/datalad_dataverse/tests/test_pydataverse.py
+++ b/datalad_dataverse/tests/test_pydataverse.py
@@ -137,9 +137,11 @@ def check_upload(api, dsid, fcontent, fpath, src_md5, dv_url):
     assert df['id']
     assert df['checksum']['type'] == 'MD5'
     assert df['md5'] == df['checksum']['value'] == src_md5
-    assert df['persistentId'] == ''
-    # TODO: seemingly discontinued between Dataverse 5.13 and 6.0?
-    #assert df['pidURL'] == ''
+    # TODO: Dataverse 6.4 started reporting persistentID and pidURL
+    assert df['persistentId'] is not ''
+    # TODO: this was seemingly discontinued between Dataverse 5.13 and
+    #  6.0, but reintrodcued in 6.4
+    assert df['pidURL'] is not ''
     assert df['rootDataFileId'] == -1
 
     if 'localhost' in dv_url or '127.0.0.1' in dv_url:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     datalad_next >= 1.0.0b2
     datalad >= 0.18.0
     pydataverse >= 0.3.4
+    looseversion
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
While it is still running on the 4.20 custom build, the data_format parameter isn't supported, and needs to be removed from the get_datafile call.